### PR TITLE
[fix]: Sidebar Navigation 내 '마이페이지' 메뉴 UI 수정 (#60)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,4 +88,7 @@ dependencies {
     // 외부 이미지 로딩 프레임워크 추가(image loading framework for Android)
     implementation 'com.github.bumptech.glide:glide:4.15.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.15.0'
+
+    // 요소 애니메이션 적용을 위한 라이브러리 추가
+    implementation 'com.daimajia.androidanimations:library:2.4@aar'
 }

--- a/app/src/debug/res/drawable/check_circle.xml
+++ b/app/src/debug/res/drawable/check_circle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="@color/light_green">
+  <path
+      android:fillColor="@color/white"
+      android:pathData="M421,571L323,473Q314,464 301,464Q288,464 279,473Q269,483 269,496.5Q269,510 278,519L400,641Q408,649 421,649Q434,649 442,641L682,401Q691,392 691,379Q691,366 681,356Q672,347 658.5,347Q645,347 635,357L421,571ZM480,880Q395,880 322,849.5Q249,819 195,765Q141,711 110.5,638Q80,565 80,480Q80,396 110.5,323Q141,250 195,196Q249,142 322,111Q395,80 480,80Q564,80 637,111Q710,142 764,196Q818,250 849,323Q880,396 880,480Q880,565 849,638Q818,711 764,765Q710,819 637,849.5Q564,880 480,880Z"/>
+</vector>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:theme="@style/Theme.Sinabro"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+
         <activity
             android:name=".IntroActivity"
             android:exported="true">
@@ -45,6 +46,8 @@
         <activity android:name="com.project.sinabro.sideBarMenu.authentication.SignIn" />
         <activity android:name="com.project.sinabro.sideBarMenu.authentication.ResetPassword" />
         <activity android:name="com.project.sinabro.sideBarMenu.devInfo.OpenSourceLicense" />
+        <activity android:name="com.project.sinabro.sideBarMenu.myPage.ModifyMyInfoActivity" />
+        <activity android:name="com.project.sinabro.sideBarMenu.myPage.ModifyPasswordActivity" />
 
         <meta-data
             android:name="com.kakao.sdk.AppKey"

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignIn.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignIn.java
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.method.PasswordTransformationMethod;
 import android.view.View;
 
 import com.project.sinabro.MainActivity;
@@ -15,6 +16,8 @@ import com.project.sinabro.textWatcher.PasswordWatcher;
 public class SignIn extends AppCompatActivity {
 
     private ActivitySignInBinding binding;
+
+    private Boolean password_toggle = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +44,19 @@ public class SignIn extends AppCompatActivity {
             public void onClick(View view) {
                 final Intent intent = new Intent(getApplicationContext(), SignUpStep1.class);
                 startActivity(intent);
+            }
+        });
+
+        /** "비밀번호 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.passwordTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (password_toggle) {
+                    binding.passwordEditText.setTransformationMethod(null);
+                    binding.passwordEditText.setPadding(34, 50, 0, 25);
+                } else
+                    binding.passwordEditText.setTransformationMethod(new PasswordTransformationMethod());
+                password_toggle = !password_toggle;
             }
         });
 

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep1.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep1.java
@@ -10,6 +10,7 @@ import com.project.sinabro.textWatcher.PasswordWatcher;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.method.PasswordTransformationMethod;
 import android.util.Log;
 import android.view.View;
 
@@ -18,6 +19,9 @@ public class SignUpStep1 extends AppCompatActivity {
     private ActivitySignUpStep1Binding binding;
 
     public static Boolean emailConfirm;
+
+    private Boolean password_toggle = true,
+            passwordConfirm_toggle = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,6 +66,32 @@ public class SignUpStep1 extends AppCompatActivity {
             }
         });
 
+        /** "비밀번호 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.passwordTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (password_toggle) {
+                    binding.passwordEditText.setPadding(34, 50, 0, 25);
+                    binding.passwordEditText.setTransformationMethod(null);
+                } else
+                    binding.passwordEditText.setTransformationMethod(new PasswordTransformationMethod());
+                password_toggle = !password_toggle;
+            }
+        });
+
+        /** "비밀번호 재확인 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.passwordConfirmTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (passwordConfirm_toggle) {
+                    binding.passwordConfirmEditText.setTransformationMethod(null);
+                    binding.passwordConfirmEditText.setPadding(34, 50, 0, 25);
+                } else
+                    binding.passwordConfirmEditText.setTransformationMethod(new PasswordTransformationMethod());
+                passwordConfirm_toggle = !passwordConfirm_toggle;
+            }
+        });
+
         /** 이메일 확인 버튼 클릭 시 이벤트 처리 코드 */
         binding.emailConfirmBtn.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -73,7 +103,7 @@ public class SignUpStep1 extends AppCompatActivity {
                 binding.emailConfirmResultTv.setTextColor(getResources().getColor(R.color.blue));
                 binding.emailConfirmResultTv.setText(getResources().getString(R.string.sign_up_email_confirm_success));
                 binding.emailTextInputLayout.setBackgroundResource(R.drawable.edt_bg_selector);
-                binding.emailTextInputLayout.setPadding(-25, 0, 0, 20);
+                binding.emailTextInputLayout.setPadding(-34, 20, 0, 20);
                 emailConfirm = true;
 
                 // 입력된 이메일이 DB 내에 이미 존재할 때 (사용 불가) 관련 문구 표기하기
@@ -100,7 +130,12 @@ public class SignUpStep1 extends AppCompatActivity {
                     binding.passwordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
                     binding.passwordTextInputLayout.setErrorEnabled(true);
                     binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-                } else if (binding.passwordConfirmTextInputLayout.getError() != null || String.valueOf(binding.passwordConfirmEditText.getText()).equals("")) {
+                } else if (!String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
+                    binding.passwordConfirmEditText.requestFocus();
+                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_current_password_validation_failed));
+                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
+                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if ((binding.passwordConfirmTextInputLayout.getError() != null || String.valueOf(binding.passwordConfirmEditText.getText()).equals("")) && !String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
                     binding.passwordConfirmEditText.requestFocus();
                     binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_confirm_validation_failed));
                     binding.passwordConfirmTextInputLayout.setErrorEnabled(true);

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep2.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep2.java
@@ -33,7 +33,7 @@ public class SignUpStep2 extends AppCompatActivity {
     private Dialog askUserUseDefaultProfileImage_dialog,
             signUpSuccess_dialog;
 
-    Bitmap bitmap;
+    private Bitmap bitmap;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyMyInfoActivity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyMyInfoActivity.java
@@ -1,0 +1,107 @@
+package com.project.sinabro.sideBarMenu.myPage;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.app.Dialog;
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.widget.Button;
+
+import com.project.sinabro.R;
+import com.project.sinabro.databinding.ActivityModifyMyInfoBinding;
+import com.project.sinabro.databinding.ActivitySignUpStep2Binding;
+import com.project.sinabro.sideBarMenu.authentication.SignIn;
+import com.project.sinabro.sideBarMenu.authentication.SignUpStep2;
+import com.project.sinabro.textWatcher.EmailWatcher;
+import com.project.sinabro.textWatcher.NicknameWatcher;
+import com.project.sinabro.toast.SuccessToast;
+
+public class ModifyMyInfoActivity extends AppCompatActivity {
+
+    private ActivityModifyMyInfoBinding binding;
+
+    public static Boolean emailConfirm;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityModifyMyInfoBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        emailConfirm = true;
+
+        /** 뒤로가기 버튼 기능 */
+        binding.backIBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                onBackPressed(); // 뒤로가기 기능 수행
+                finish(); // 현재 액티비티 종료
+            }
+        });
+
+        /** TextInputLayout helper 생성 관련 코드 */
+        binding.nicknameTextInputLayout.getEditText().addTextChangedListener(new NicknameWatcher(binding.nicknameTextInputLayout, getResources().getString(R.string.sign_up_nickname_failed)));
+        binding.emailTextInputLayout.getEditText().addTextChangedListener(new EmailWatcher(binding.emailTextInputLayout, binding.emailConfirmResultTv, getResources().getString(R.string.sign_up_email), "ModifyMyInfoActivity"));
+
+        /** 이메일 내용 지우기 X 버튼 클릭 시  */
+        binding.emailTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Do something when the end icon is clicked
+                emailConfirm = false;
+                binding.emailEditText.setText("");
+                binding.emailConfirmResultTv.setVisibility(View.GONE);
+            }
+        });
+
+        /** 이메일 확인 버튼 클릭 시 이벤트 처리 코드 */
+        binding.emailConfirmBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                /* 이곳에 API 호출 코드가 추가되어야 합니다. */
+
+                // 입력된 이메일이 DB 내에 존재하지 않을 때 (사용 가능) 관련 문구 표기하기
+                binding.emailTextInputLayout.setErrorEnabled(false);
+                binding.emailConfirmResultTv.setTextColor(getResources().getColor(R.color.blue));
+                binding.emailConfirmResultTv.setText(getResources().getString(R.string.sign_up_email_confirm_success));
+                binding.emailTextInputLayout.setBackgroundResource(R.drawable.edt_bg_selector);
+                binding.emailTextInputLayout.setPadding(-34, 20, 0, 20);
+                emailConfirm = true;
+
+                // 입력된 이메일이 DB 내에 이미 존재할 때 (사용 불가) 관련 문구 표기하기
+//                binding.emailConfirmResultTv.setTextColor(getResources().getColor(R.color.red));
+//                binding.emailConfirmResultTv.setText(getResources().getString(R.string.signup_email_confirm_failed));
+
+                binding.emailConfirmResultTv.setVisibility(View.VISIBLE);
+                binding.emailEditText.clearFocus();
+            }
+        });
+
+        binding.modifyCompleteBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // 입력 란 검증 실패 및 공란 확인 조건식
+                if (String.valueOf(binding.nicknameEditText.getText()).equals("")) {
+                    binding.nicknameEditText.requestFocus();
+                    binding.nicknameTextInputLayout.setError(getResources().getString(R.string.sign_up_nickname_failed));
+                    binding.nicknameTextInputLayout.setErrorEnabled(true);
+                    binding.nicknameTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if (!emailConfirm || String.valueOf(binding.emailEditText.getText()).equals("") || !emailConfirm) {
+                    binding.emailEditText.requestFocus();
+                    binding.emailTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_email_validation_failed));
+                    binding.emailTextInputLayout.setErrorEnabled(true);
+                    binding.emailTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else {
+                    // 모든 입력이 정상적으로 완료되었을 때
+                    new SuccessToast(getResources().getString(R.string.toast_modify_my_info_success), ModifyMyInfoActivity.this);
+                    onBackPressed(); // 뒤로가기 기능 수행
+                    finish(); // 현재 액티비티 종료
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyPasswordActivity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyPasswordActivity.java
@@ -99,40 +99,40 @@ public class ModifyPasswordActivity extends AppCompatActivity {
         binding.modifyCompleteBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                new SuccessToast(getResources().getString(R.string.toast_modify_password_success), ModifyPasswordActivity.this);
-//                if (binding.currentPasswordTextInputLayout.getError() != null || String.valueOf(binding.currentPasswordEditText.getText()).equals("")) {
-//                    binding.currentPasswordEditText.requestFocus();
-//                    binding.currentPasswordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
-//                    binding.currentPasswordTextInputLayout.setErrorEnabled(true);
-//                    binding.currentPasswordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-//                } else if (String.valueOf(binding.currentPasswordEditText.getText()).equals(String.valueOf(binding.passwordEditText.getText()))) {
-//                    binding.passwordEditText.requestFocus();
-//                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.current_and_new_password_same));
-//                    binding.passwordTextInputLayout.setErrorEnabled(true);
-//                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-//                } else if (binding.passwordTextInputLayout.getError() != null || String.valueOf(binding.passwordEditText.getText()).equals("")) {
-//                    binding.passwordEditText.requestFocus();
-//                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
-//                    binding.passwordTextInputLayout.setErrorEnabled(true);
-//                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-//                } else if (!String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
-//                    binding.passwordConfirmEditText.requestFocus();
-//                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_current_password_validation_failed));
-//                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
-//                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-//                } else if ((binding.passwordConfirmTextInputLayout.getError() != null || String.valueOf(binding.passwordConfirmEditText.getText()).equals("")) && !String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
-//                    binding.passwordConfirmEditText.requestFocus();
-//                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_confirm_validation_failed));
-//                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
-//                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
-//                } else {
-//                    // showDialog_modify_password_failed();
-//
-//                    // 모든 입력이 정상적으로 완료되었을 때
-//                    new SuccessToast(getResources().getString(R.string.toast_modify_password_success), ModifyPasswordActivity.this);
-//                    onBackPressed(); // 뒤로가기 기능 수행
-//                    finish(); // 현재 액티비티 종료
-//                }
+                // 입력 란 검증 실패 및 공란 확인 조건식
+                if (binding.currentPasswordTextInputLayout.getError() != null || String.valueOf(binding.currentPasswordEditText.getText()).equals("")) {
+                    binding.currentPasswordEditText.requestFocus();
+                    binding.currentPasswordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
+                    binding.currentPasswordTextInputLayout.setErrorEnabled(true);
+                    binding.currentPasswordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if (String.valueOf(binding.currentPasswordEditText.getText()).equals(String.valueOf(binding.passwordEditText.getText()))) {
+                    binding.passwordEditText.requestFocus();
+                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.current_and_new_password_same));
+                    binding.passwordTextInputLayout.setErrorEnabled(true);
+                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if (binding.passwordTextInputLayout.getError() != null || String.valueOf(binding.passwordEditText.getText()).equals("")) {
+                    binding.passwordEditText.requestFocus();
+                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
+                    binding.passwordTextInputLayout.setErrorEnabled(true);
+                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if (!String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
+                    binding.passwordConfirmEditText.requestFocus();
+                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_current_password_validation_failed));
+                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
+                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else if ((binding.passwordConfirmTextInputLayout.getError() != null || String.valueOf(binding.passwordConfirmEditText.getText()).equals("")) && !String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
+                    binding.passwordConfirmEditText.requestFocus();
+                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_confirm_validation_failed));
+                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
+                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+                } else {
+                    // showDialog_modify_password_failed();
+
+                    // 모든 입력이 정상적으로 완료되었을 때
+                    new SuccessToast(getResources().getString(R.string.toast_modify_password_success), ModifyPasswordActivity.this);
+                    onBackPressed(); // 뒤로가기 기능 수행
+                    finish(); // 현재 액티비티 종료
+                }
             }
         });
     }

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyPasswordActivity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/ModifyPasswordActivity.java
@@ -1,0 +1,160 @@
+package com.project.sinabro.sideBarMenu.myPage;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.app.Dialog;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.text.method.PasswordTransformationMethod;
+import android.util.Log;
+import android.view.View;
+import android.view.Window;
+
+import com.daimajia.androidanimations.library.Techniques;
+import com.daimajia.androidanimations.library.YoYo;
+import com.project.sinabro.R;
+import com.project.sinabro.databinding.ActivityModifyPasswordBinding;
+import com.project.sinabro.textWatcher.PasswordConfirmWatcher;
+import com.project.sinabro.textWatcher.PasswordWatcher;
+import com.project.sinabro.toast.SuccessToast;
+
+public class ModifyPasswordActivity extends AppCompatActivity {
+
+    private ActivityModifyPasswordBinding binding;
+
+    private Boolean current_password_toggle = true, password_toggle = true, passwordConfirm_toggle = true;
+
+    private Dialog modify_password_failed_dialog;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityModifyPasswordBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        /** "비밀번호 변경 실패 안내" 다이얼로그 변수 초기화 및 설정 */
+        modify_password_failed_dialog = new Dialog(ModifyPasswordActivity.this);  // Dialog 초기화
+        modify_password_failed_dialog.requestWindowFeature(Window.FEATURE_NO_TITLE); // 타이틀 제거
+        modify_password_failed_dialog.setContentView(R.layout.dialog_modify_password_failed); // xml 레이아웃 파일과 연결
+        // dialog 창의 root 레이아웃을 투명하게 조절 모서리(코너)를 둥글게 보이게 하기 위해
+        modify_password_failed_dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+
+        /** 뒤로가기 버튼 기능 */
+        binding.backIBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                onBackPressed(); // 뒤로가기 기능 수행
+                finish(); // 현재 액티비티 종료
+            }
+        });
+
+        /** TextInputLayout helper 생성 관련 코드 */
+        binding.currentPasswordTextInputLayout.getEditText().addTextChangedListener(new PasswordWatcher(binding.currentPasswordTextInputLayout, getResources().getString(R.string.sign_in_password_failed)));
+        binding.passwordTextInputLayout.getEditText().addTextChangedListener(new PasswordWatcher(binding.passwordTextInputLayout, getResources().getString(R.string.sign_up_password)));
+        binding.passwordConfirmTextInputLayout.getEditText().addTextChangedListener(new PasswordConfirmWatcher(binding.passwordTextInputLayout, binding.passwordConfirmTextInputLayout, getResources().getString(R.string.sign_up_step1_password_confirm_validation_failed)));
+
+        /** "현재 비밀번호 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.currentPasswordTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d("테스트", "" + current_password_toggle);
+                if (current_password_toggle) {
+                    binding.currentPasswordEditText.setTransformationMethod(null);
+                    binding.currentPasswordEditText.setPadding(34, 50, 0, 25);
+                } else
+                    binding.currentPasswordEditText.setTransformationMethod(new PasswordTransformationMethod());
+                current_password_toggle = !current_password_toggle;
+            }
+        });
+
+        /** "비밀번호 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.passwordTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d("테스트", "" + current_password_toggle);
+                if (password_toggle) {
+                    binding.passwordEditText.setTransformationMethod(null);
+                    binding.passwordEditText.setPadding(34, 50, 0, 25);
+                } else
+                    binding.passwordEditText.setTransformationMethod(new PasswordTransformationMethod());
+                password_toggle = !password_toggle;
+            }
+        });
+
+        /** "비밀번호 재확인 입력 란" 비밀번호 show/hidden 아이콘 클릭 시 */
+        binding.passwordConfirmTextInputLayout.setEndIconOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d("테스트", "" + current_password_toggle);
+                if (passwordConfirm_toggle) {
+                    binding.passwordConfirmEditText.setTransformationMethod(null);
+                    binding.passwordConfirmEditText.setPadding(34, 50, 0, 25);
+                } else
+                    binding.passwordConfirmEditText.setTransformationMethod(new PasswordTransformationMethod());
+                passwordConfirm_toggle = !passwordConfirm_toggle;
+            }
+        });
+
+        binding.modifyCompleteBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                new SuccessToast(getResources().getString(R.string.toast_modify_password_success), ModifyPasswordActivity.this);
+//                if (binding.currentPasswordTextInputLayout.getError() != null || String.valueOf(binding.currentPasswordEditText.getText()).equals("")) {
+//                    binding.currentPasswordEditText.requestFocus();
+//                    binding.currentPasswordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
+//                    binding.currentPasswordTextInputLayout.setErrorEnabled(true);
+//                    binding.currentPasswordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+//                } else if (String.valueOf(binding.currentPasswordEditText.getText()).equals(String.valueOf(binding.passwordEditText.getText()))) {
+//                    binding.passwordEditText.requestFocus();
+//                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.current_and_new_password_same));
+//                    binding.passwordTextInputLayout.setErrorEnabled(true);
+//                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+//                } else if (binding.passwordTextInputLayout.getError() != null || String.valueOf(binding.passwordEditText.getText()).equals("")) {
+//                    binding.passwordEditText.requestFocus();
+//                    binding.passwordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_validation_failed));
+//                    binding.passwordTextInputLayout.setErrorEnabled(true);
+//                    binding.passwordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+//                } else if (!String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
+//                    binding.passwordConfirmEditText.requestFocus();
+//                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_current_password_validation_failed));
+//                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
+//                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+//                } else if ((binding.passwordConfirmTextInputLayout.getError() != null || String.valueOf(binding.passwordConfirmEditText.getText()).equals("")) && !String.valueOf(binding.passwordEditText.getText()).equals(String.valueOf(binding.passwordConfirmEditText.getText()))) {
+//                    binding.passwordConfirmEditText.requestFocus();
+//                    binding.passwordConfirmTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_password_confirm_validation_failed));
+//                    binding.passwordConfirmTextInputLayout.setErrorEnabled(true);
+//                    binding.passwordConfirmTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+//                } else {
+//                    // showDialog_modify_password_failed();
+//
+//                    // 모든 입력이 정상적으로 완료되었을 때
+//                    new SuccessToast(getResources().getString(R.string.toast_modify_password_success), ModifyPasswordActivity.this);
+//                    onBackPressed(); // 뒤로가기 기능 수행
+//                    finish(); // 현재 액티비티 종료
+//                }
+            }
+        });
+    }
+
+    /**
+     * (dialog_modify_password_failed) 다이얼로그를 디자인하는 함수
+     */
+    public void showDialog_modify_password_failed() {
+        modify_password_failed_dialog.show(); // 다이얼로그 띄우기
+        // 다이얼로그 창이 나타나면서 외부 액티비티가 어두워지는데, 그 정도를 조절함
+        modify_password_failed_dialog.getWindow().setDimAmount(0.35f);
+
+        // "확인" 버튼
+        modify_password_failed_dialog.findViewById(R.id.yesBtn).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                modify_password_failed_dialog.dismiss(); // 다이얼로그 닫기
+                binding.currentPasswordEditText.requestFocus();
+                binding.currentPasswordTextInputLayout.setError(getResources().getString(R.string.sign_up_step1_current_password_validation_failed));
+                binding.currentPasswordTextInputLayout.setErrorEnabled(true);
+                binding.currentPasswordTextInputLayout.setBackgroundResource(R.drawable.edt_bg_only_helper_selected);
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/MyPageFragment.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/MyPageFragment.java
@@ -1,15 +1,36 @@
 package com.project.sinabro.sideBarMenu.myPage;
 
+import static android.app.Activity.RESULT_OK;
+
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.fragment.app.Fragment;
 
+import android.provider.MediaStore;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageButton;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
 
+import com.daimajia.androidanimations.library.Techniques;
+import com.daimajia.androidanimations.library.YoYo;
+import com.makeramen.roundedimageview.RoundedImageView;
 import com.project.sinabro.R;
+
+import java.io.InputStream;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -24,6 +45,16 @@ public class MyPageFragment extends Fragment {
     private static final String ARG_PARAM2 = "param2";
 
     private ImageButton back_ibtn;
+
+    private TextView modify_my_info_tv;
+
+    private RoundedImageView userImage_roundedImageView;
+
+    private RelativeLayout password_relativeLayout;
+
+    private Bitmap bitmap;
+
+    private Button modify_complete_btn;
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -60,15 +91,15 @@ public class MyPageFragment extends Fragment {
             mParam2 = getArguments().getString(ARG_PARAM2);
         }
     }
-/*뒤로가기*/
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_my_page_activity, container, false);
 
-        // 뒤로가기 버튼 기능
-        back_ibtn = (ImageButton) view.findViewById(R.id.back_ibtn);
+        /** 뒤로가기 버튼 기능 */
+        back_ibtn = (ImageButton) view.findViewById(R.id.back_iBtn);
         back_ibtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -76,6 +107,120 @@ public class MyPageFragment extends Fragment {
             }
         });
 
+        /** "마이페이지(fragment)"에서 "정보 수정(activity)"로 화면 전환 코드 추가 */
+        modify_my_info_tv = (TextView) view.findViewById(R.id.modify_my_info_tv);
+        modify_my_info_tv.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // "정보 수정" 액티비티로 이동
+                // fragment이기 때문에 activity intent와는 다른 방식
+                Intent intent = new Intent(getActivity(), ModifyMyInfoActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                startActivity(intent);
+            }
+        });
+
+        userImage_roundedImageView = (RoundedImageView) view.findViewById(R.id.userImage_roundedImageView);
+        userImage_roundedImageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                //갤러리 호출
+                Intent intent = new Intent(Intent.ACTION_PICK);
+                intent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*");
+                intent.setAction(Intent.ACTION_PICK);
+                activityResultLauncher.launch(intent);
+            }
+        });
+
+        /** "마이페이지(fragment)"에서 "비밀번호 변경(activity)"로 화면 전환r 코드 추가 */
+        password_relativeLayout = (RelativeLayout) view.findViewById(R.id.password_relativeLayout);
+        password_relativeLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // "비밀번호 변경" 액티비티로 이동
+                // fragment이기 때문에 activity intent와는 다른 방식
+                Intent intent = new Intent(getActivity(), ModifyPasswordActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                startActivity(intent);
+            }
+        });
+
+        modify_complete_btn = (Button) view.findViewById(R.id.modify_complete_btn);
+        modify_complete_btn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Log.d("테스트", "홀리몰리");
+            }
+        });
+
         return view;
+    }
+
+    ActivityResultLauncher<Intent> activityResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (result.getResultCode() == RESULT_OK) {
+                        int calRatio = calculateInSampleSize(
+                                result.getData().getData()
+                                , getResources().getDimensionPixelSize(R.dimen.imgSize)
+                                , getResources().getDimensionPixelSize(R.dimen.imgSize)
+                        );
+
+                        BitmapFactory.Options option = new BitmapFactory.Options();
+                        option.inSampleSize = calRatio;
+
+                        try {
+                            InputStream inputStream = getContext().getContentResolver().openInputStream(result.getData().getData());
+                            bitmap = BitmapFactory.decodeStream(inputStream, null, option);
+                            inputStream.close();
+                            if (bitmap != null) {
+                                modify_complete_btn.setVisibility(View.VISIBLE);
+                                userImage_roundedImageView.setImageBitmap(bitmap);
+                                YoYo.with(Techniques.FadeInUp)
+                                        .duration(500)
+                                        .repeat(0)
+                                        .playOn(getView().findViewById(R.id.modify_complete_btn));
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+    );
+
+    private int calculateInSampleSize(Uri fileUri, int reqWidth, int reqHeight) {
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+
+        try {
+            InputStream inputStream = getContext().getContentResolver().openInputStream(fileUri);
+
+            // inJustDecodeBounds 값을 true 로 설정한 상태에서 decodeXXX() 를 호출.
+            // 로딩 하고자 하는 이미지의 각종 정보가 options 에 설정 된다.
+            BitmapFactory.decodeStream(inputStream, null, options);
+            inputStream.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // 비율 계산
+        int width = options.outWidth;
+        int height = options.outHeight;
+        int inSampleSize = 1;
+
+        //inSampleSize 비율 계산
+        if (height > reqHeight || width > reqWidth) {
+
+            int halfHeight = height / 2;
+            int halfWidth = width / 2;
+
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2;
+            }
+        }
+        return inSampleSize;
     }
 }

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/MyPageFragment.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/myPage/MyPageFragment.java
@@ -29,6 +29,7 @@ import com.daimajia.androidanimations.library.Techniques;
 import com.daimajia.androidanimations.library.YoYo;
 import com.makeramen.roundedimageview.RoundedImageView;
 import com.project.sinabro.R;
+import com.project.sinabro.toast.SuccessToast;
 
 import java.io.InputStream;
 
@@ -149,7 +150,8 @@ public class MyPageFragment extends Fragment {
         modify_complete_btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Log.d("테스트", "홀리몰리");
+                modify_complete_btn.setVisibility(View.INVISIBLE);
+                new SuccessToast(getResources().getString(R.string.toast_modify_user_image_success), getActivity());
             }
         });
 
@@ -176,8 +178,8 @@ public class MyPageFragment extends Fragment {
                             bitmap = BitmapFactory.decodeStream(inputStream, null, option);
                             inputStream.close();
                             if (bitmap != null) {
-                                modify_complete_btn.setVisibility(View.VISIBLE);
                                 userImage_roundedImageView.setImageBitmap(bitmap);
+                                modify_complete_btn.setVisibility(View.VISIBLE);
                                 YoYo.with(Techniques.FadeInUp)
                                         .duration(500)
                                         .repeat(0)

--- a/app/src/main/java/com/project/sinabro/textWatcher/EmailWatcher.java
+++ b/app/src/main/java/com/project/sinabro/textWatcher/EmailWatcher.java
@@ -10,6 +10,8 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.project.sinabro.R;
 import com.project.sinabro.sideBarMenu.authentication.SignUpStep1;
+import com.project.sinabro.sideBarMenu.myPage.ModifyMyInfoActivity;
+import com.project.sinabro.sideBarMenu.myPage.ModifyPasswordActivity;
 
 public class EmailWatcher implements TextWatcher {
 
@@ -19,11 +21,11 @@ public class EmailWatcher implements TextWatcher {
 
     private TextView emailConfirmResultTv;
 
-    private final String errorMsg;
-
-    private String calledActivityName;
+    private final String errorMsg, calledActivityName;
 
     private final SignUpStep1 signUpStep1 = new SignUpStep1();
+
+    private final ModifyMyInfoActivity modifyMyInfoActivity = new ModifyMyInfoActivity();
 
     public EmailWatcher(TextInputLayout textInputLayout, TextInputEditText textInputEditText, String errorMsg, String calledActivityName) {
         this.emailTextLayout = textInputLayout;
@@ -56,9 +58,13 @@ public class EmailWatcher implements TextWatcher {
 
     @Override
     public void afterTextChanged(Editable s) {
-        // SignUpStep1 액티비티에서 호출된 EmailWatcher의 경우, 하단의 if문 실행
         if (calledActivityName.equals("SignUpStep1") && signUpStep1.emailConfirm) {
+            // (SignUpStep1 액티비티)에서 호출된 EmailWatcher의 경우, 하단의 문장 실행
             signUpStep1.emailConfirm = false;
+            emailConfirmResultTv.setVisibility(View.GONE);
+        } else if (calledActivityName.equals("ModifyMyInfoActivity") && modifyMyInfoActivity.emailConfirm) {
+            // (ModifyMyInfoActivity 액티비티)에서 호출된 EmailWatcher의 경우, 하단의 문장 실행
+            modifyMyInfoActivity.emailConfirm = false;
             emailConfirmResultTv.setVisibility(View.GONE);
         }
 
@@ -66,7 +72,7 @@ public class EmailWatcher implements TextWatcher {
             emailTextLayout.setError(null);
             emailTextLayout.setErrorEnabled(false);
             emailTextLayout.setBackgroundResource(R.drawable.edt_bg_selector);
-            emailTextLayout.setPadding(-25, 0, 0, 20);
+            emailTextLayout.setPadding(-34, 20, 0, 20);
         } else if (!validateEmail(s.toString())) {
             emailTextLayout.setError(errorMsg);
             emailTextLayout.setErrorEnabled(true);
@@ -75,7 +81,7 @@ public class EmailWatcher implements TextWatcher {
             emailTextLayout.setError(null);
             emailTextLayout.setErrorEnabled(false);
             emailTextLayout.setBackgroundResource(R.drawable.edt_bg_selector);
-            emailTextLayout.setPadding(-25, 0, 0, 20);
+            emailTextLayout.setPadding(-34, 20, 0, 20);
         }
     }
 

--- a/app/src/main/java/com/project/sinabro/textWatcher/NicknameWatcher.java
+++ b/app/src/main/java/com/project/sinabro/textWatcher/NicknameWatcher.java
@@ -52,7 +52,7 @@ public class NicknameWatcher implements TextWatcher {
             nicknameTextLayout.setError(null);
             nicknameTextLayout.setErrorEnabled(false);
             nicknameTextLayout.setBackgroundResource(R.drawable.edt_bg_selector);
-            nicknameTextLayout.setPadding(-25, 0, 0, 20);
+            nicknameTextLayout.setPadding(-34, 20, 0, 20);
         } else if (!validateNickname(s.toString())) {
             nicknameTextLayout.setError(errorMsg);
             nicknameTextLayout.setErrorEnabled(true);
@@ -61,7 +61,7 @@ public class NicknameWatcher implements TextWatcher {
             nicknameTextLayout.setError(null);
             nicknameTextLayout.setErrorEnabled(false);
             nicknameTextLayout.setBackgroundResource(R.drawable.edt_bg_selector);
-            nicknameTextLayout.setPadding(-25, 0, 0, 20);
+            nicknameTextLayout.setPadding(-34, 20, 0, 20);
         }
     }
 

--- a/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
+++ b/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
@@ -2,7 +2,6 @@ package com.project.sinabro.textWatcher;
 
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.widget.TextView;
 
 import com.google.android.material.textfield.TextInputEditText;

--- a/app/src/main/java/com/project/sinabro/toast/SuccessToast.java
+++ b/app/src/main/java/com/project/sinabro/toast/SuccessToast.java
@@ -1,0 +1,23 @@
+package com.project.sinabro.toast;
+
+import android.app.Activity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.project.sinabro.R;
+
+public class SuccessToast {
+    public SuccessToast(String message, Activity activity) {
+        Toast toast = new Toast(activity);
+        View view = LayoutInflater.from(activity)
+                .inflate(R.layout.toast_modify_success, null);
+
+        TextView tvMessage = view.findViewById(R.id.toast_modify_success_tv);
+        tvMessage.setText(message);
+
+        toast.setView(view);
+        toast.show();
+    }
+}

--- a/app/src/main/res/layout/activity_add_location_info.xml
+++ b/app/src/main/res/layout/activity_add_location_info.xml
@@ -6,128 +6,143 @@
     android:layout_height="match_parent"
     tools:context=".bottomSheet.place.AddLocationInfoActivity">
 
-    <!-- 뒤로가기 버튼 -->
-    <ImageButton
-        android:id="@+id/back_iBtn"
-        android:layout_width="42.5dp"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="5dp"
-        android:layout_marginTop="10dp"
-        android:backgroundTint="#FFFFFF"
-        android:src="@drawable/back"
-        tools:ignore="SpeakableTextPresentCheck" />
+    <!-- activity (header) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/activity_header_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <!-- "장소 등록" 메뉴명 -->
-    <TextView
-        android:id="@+id/activityTitle_tv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="27.5dp"
-        android:letterSpacing="-0.01"
-        android:text="장소 등록"
-        android:textColor="@color/dark_grey"
-        android:textSize="17.5sp" />
+        <!-- 뒤로가기 버튼 -->
+        <ImageButton
+            android:id="@+id/back_iBtn"
+            android:layout_width="42.5dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="10dp"
+            android:backgroundTint="#FFFFFF"
+            android:src="@drawable/back"
+            tools:ignore="SpeakableTextPresentCheck" />
 
-    <!-- 장소 삭제하기 버튼 -->
-    <TextView
-        android:id="@+id/placeRemove_tv"
-        android:layout_width="50dp"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="28dp"
-        android:layout_marginRight="10dp"
-        android:letterSpacing="-0.01"
-        android:text="삭제"
-        android:textAlignment="center"
-        android:textColor="@color/dark_grey"
-        android:textSize="16sp"
-        android:visibility="invisible" />
-
-    <!-- 도로명 주소 레이블 -->
-    <TextView
-        android:id="@+id/roadNameAddress_label_tv"
-        android:layout_width="350dp"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_marginLeft="23dp"
-        android:layout_marginTop="110dp"
-        android:letterSpacing="-0.05"
-        android:text="현재 위치"
-        android:textColor="@color/input_label"
-        android:textSize="15sp" />
-
-    <!-- (위도, 경도) 기반 도로명 주소 -->
-    <TextView
-        android:id="@+id/roadNameAddress_tv"
-        android:layout_width="350dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/roadNameAddress_label_tv"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="10dp"
-        android:letterSpacing="-0.05"
-        android:text="충청북도 청주시 서원구 충대로1 충북대학교"
-        android:textColor="@color/dark_grey"
-        android:textSize="20sp" />
-
-    <!-- 장소명 -->
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/placeName_textInputLayout"
-        android:layout_width="350dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/roadNameAddress_tv"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="18.5dp"
-        android:background="@drawable/edt_bg_selector"
-        android:hint="장소명"
-        android:paddingLeft="-12.5dp"
-        android:textColorHint="@color/input_hint"
-        app:boxBackgroundMode="none"
-        app:endIconMode="clear_text"
-        app:hintTextAppearance="@style/App.hintTextAppearance"
-        app:hintTextColor="@color/input_label">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/placeName_editText"
-            android:layout_width="362.5dp"
-            android:layout_height="match_parent"
-            android:ellipsize="end"
-            android:inputType="textNoSuggestions"
-            android:maxLength="14"
-            android:paddingTop="12dp"
+        <!-- "장소 등록" 메뉴명 -->
+        <TextView
+            android:id="@+id/activityTitle_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="27.5dp"
+            android:letterSpacing="-0.01"
+            android:text="장소 등록"
             android:textColor="@color/dark_grey"
-            android:textCursorDrawable="@drawable/cursor_color"
-            android:textSize="20sp" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:textSize="17.5sp" />
 
-    <!-- 상세주소 -->
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/detailAddress_textInputLayout"
-        android:layout_width="350dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/placeName_textInputLayout"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="19.5dp"
-        android:background="@drawable/edt_bg_selector"
-        android:hint="상세주소"
-        android:paddingLeft="-12.5dp"
-        android:textColorHint="@color/input_hint"
-        app:boxBackgroundMode="none"
-        app:endIconMode="clear_text"
-        app:hintTextAppearance="@style/App.hintTextAppearance"
-        app:hintTextColor="@color/input_label">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/detailAddress_editText"
-            android:layout_width="362.5dp"
-            android:layout_height="match_parent"
-            android:inputType="textNoSuggestions"
-            android:maxLength="14"
-            android:paddingTop="12dp"
+        <!-- "장소 삭제" TextView -->
+        <TextView
+            android:id="@+id/placeRemove_tv"
+            android:layout_width="60dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerInParent="true"
+            android:layout_marginTop="29dp"
+            android:layout_marginEnd="10dp"
+            android:gravity="center"
+            android:letterSpacing="-0.01"
+            android:text="삭제"
             android:textColor="@color/dark_grey"
-            android:textCursorDrawable="@drawable/cursor_color"
+            android:textSize="16sp" />
+    </RelativeLayout>
+
+    <!-- activity (body) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/activity_body_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/activity_header_relativeLayout">
+
+        <!-- 도로명 주소 레이블 -->
+        <TextView
+            android:id="@+id/roadNameAddress_label_tv"
+            android:layout_width="350dp"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginLeft="23dp"
+            android:layout_marginTop="110dp"
+            android:letterSpacing="-0.05"
+            android:text="현재 위치"
+            android:textColor="@color/input_label"
+            android:textSize="15sp" />
+
+        <!-- (위도, 경도) 기반 도로명 주소 -->
+        <TextView
+            android:id="@+id/roadNameAddress_tv"
+            android:layout_width="350dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/roadNameAddress_label_tv"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="10dp"
+            android:letterSpacing="-0.05"
+            android:text="충청북도 청주시 서원구 충대로1 충북대학교"
+            android:textColor="@color/dark_grey"
             android:textSize="20sp" />
-    </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 장소명 -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/placeName_textInputLayout"
+            android:layout_width="350dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/roadNameAddress_tv"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="18.5dp"
+            android:background="@drawable/edt_bg_selector"
+            android:hint="장소명"
+            android:paddingLeft="-12.5dp"
+            android:textColorHint="@color/input_hint"
+            app:boxBackgroundMode="none"
+            app:endIconMode="clear_text"
+            app:hintTextAppearance="@style/App.hintTextAppearance"
+            app:hintTextColor="@color/input_label">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/placeName_editText"
+                android:layout_width="362.5dp"
+                android:layout_height="match_parent"
+                android:ellipsize="end"
+                android:inputType="textNoSuggestions"
+                android:maxLength="14"
+                android:paddingTop="12dp"
+                android:textColor="@color/dark_grey"
+                android:textCursorDrawable="@drawable/cursor_color"
+                android:textSize="20sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 상세주소 -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/detailAddress_textInputLayout"
+            android:layout_width="350dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/placeName_textInputLayout"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="19.5dp"
+            android:background="@drawable/edt_bg_selector"
+            android:hint="상세주소"
+            android:paddingLeft="-12.5dp"
+            android:textColorHint="@color/input_hint"
+            app:boxBackgroundMode="none"
+            app:endIconMode="clear_text"
+            app:hintTextAppearance="@style/App.hintTextAppearance"
+            app:hintTextColor="@color/input_label">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/detailAddress_editText"
+                android:layout_width="362.5dp"
+                android:layout_height="match_parent"
+                android:inputType="textNoSuggestions"
+                android:maxLength="14"
+                android:paddingTop="12dp"
+                android:textColor="@color/dark_grey"
+                android:textCursorDrawable="@drawable/cursor_color"
+                android:textSize="20sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </RelativeLayout>
 
     <!-- 장소 등록하기 버튼 -->
     <Button

--- a/app/src/main/res/layout/activity_modify_my_info.xml
+++ b/app/src/main/res/layout/activity_modify_my_info.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".sideBarMenu.myPage.ModifyMyInfoActivity">
+
+    <!-- fragment (header) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/fragment_header_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- 뒤로가기 버튼 -->
+        <ImageButton
+            android:id="@+id/back_iBtn"
+            android:layout_width="42.5dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="10dp"
+            android:backgroundTint="@color/transparent"
+            android:src="@drawable/back"
+            tools:ignore="SpeakableTextPresentCheck" />
+
+        <!-- "~~~님의 정보" 메뉴명 -->
+        <TextView
+            android:id="@+id/my_page_fragment_title_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="27.5dp"
+            android:letterSpacing="-0.01"
+            android:text="내 정보 수정"
+            android:textColor="@color/dark_grey"
+            android:textSize="17.5sp" />
+    </RelativeLayout>
+
+    <!-- fragment (body) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/fragment_body_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/fragment_header_relativeLayout">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <RelativeLayout
+                    android:id="@+id/nickname_relativeLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <!-- 이름 입력 TextInputLayout -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/nickname_textInputLayout"
+                        android:layout_width="325dp"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:layout_marginTop="27.5dp"
+                        android:background="@drawable/edt_bg_selector"
+                        android:hint="이름"
+                        android:paddingLeft="-12.5dp"
+                        android:textColorHint="@color/input_hint"
+                        app:boxBackgroundMode="none"
+                        app:hintTextAppearance="@style/App.hintSmallTextAppearance"
+                        app:hintTextColor="@color/input_label">
+
+                        <!-- 이름 입력 란 -->
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/nickname_editText"
+                            android:layout_width="337.5dp"
+                            android:layout_height="match_parent"
+                            android:ellipsize="end"
+                            android:inputType="textNoSuggestions"
+                            android:maxLength="10"
+                            android:paddingTop="12dp"
+                            android:text="홍길동"
+                            android:textColor="@color/dark_grey"
+                            android:textCursorDrawable="@drawable/cursor_color"
+                            android:textSize="17.5sp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:layout_below="@+id/nickname_relativeLayout">
+
+                    <!-- 이메일 입력 TextInputLayout -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/email_textInputLayout"
+                        android:layout_width="325dp"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:background="@drawable/edt_bg_selector"
+                        android:hint="이메일"
+                        android:paddingLeft="-12.5dp"
+                        android:textColorHint="@color/input_hint"
+                        app:boxBackgroundMode="none"
+                        app:endIconMode="clear_text"
+                        app:hintTextAppearance="@style/App.hintSmallTextAppearance"
+                        app:hintTextColor="@color/input_label">
+
+                        <!-- 이메일 입력 란 -->
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/email_editText"
+                            android:layout_width="337.5dp"
+                            android:layout_height="match_parent"
+                            android:ellipsize="end"
+                            android:inputType="textNoSuggestions"
+                            android:textColor="@color/dark_grey"
+                            android:paddingTop="12dp"
+                            android:text="abc123@naver.com"
+                            android:textCursorDrawable="@drawable/cursor_color"
+                            android:textSize="17.5sp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <!-- 이메일 확인 성공/실패 안내 TextView -->
+                    <TextView
+                        android:id="@+id/emailConfirmResult_tv"
+                        android:layout_width="320dp"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/email_textInputLayout"
+                        android:layout_centerHorizontal="true"
+                        android:layout_marginTop="2.5dp"
+                        android:layout_marginBottom="2.5dp"
+                        android:textColor="@color/red"
+                        android:visibility="gone" />
+
+                    <!-- 이메일 중복 확인 버튼 -->
+                    <Button
+                        android:id="@+id/emailConfirm_btn"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/email_textInputLayout"
+                        android:layout_alignRight="@+id/email_textInputLayout"
+                        android:backgroundTint="@color/blue"
+                        android:text="이메일 확인" />
+                </RelativeLayout>
+            </RelativeLayout>
+        </ScrollView>
+    </RelativeLayout>
+
+    <!-- "수정 완료" 버튼 -->
+    <Button
+        android:id="@+id/modify_complete_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="22.5dp"
+        android:backgroundTint="@color/blue"
+        android:letterSpacing="0"
+        android:outlineProvider="none"
+        android:paddingTop="17.5dp"
+        android:paddingBottom="17.5dp"
+        android:text="수정 완료"
+        android:textColor="@color/white"
+        android:textSize="17.5sp"
+        app:cornerRadius="13dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_modify_password.xml
+++ b/app/src/main/res/layout/activity_modify_password.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".sideBarMenu.myPage.ModifyPasswordActivity">
+
+    <!-- activity (header) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/activity_header_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- 뒤로가기 버튼 -->
+        <ImageButton
+            android:id="@+id/back_iBtn"
+            android:layout_width="42.5dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="10dp"
+            android:backgroundTint="@color/transparent"
+            android:src="@drawable/back"
+            tools:ignore="SpeakableTextPresentCheck" />
+
+        <!-- "~~~님의 정보" 메뉴명 -->
+        <TextView
+            android:id="@+id/modify_password_title_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="27.5dp"
+            android:letterSpacing="-0.01"
+            android:text="비밀번호 변경"
+            android:textColor="@color/dark_grey"
+            android:textSize="17.5sp" />
+
+    </RelativeLayout>
+
+    <!-- activity (body) RelativeLayout -->
+    <RelativeLayout
+        android:id="@+id/activity_body_relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/activity_header_relativeLayout"
+        android:layout_marginTop="20dp">
+
+        <!-- 현재 비밀번호 입력 TextInputLayout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/current_password_textInputLayout"
+            android:layout_width="325dp"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="18.5dp"
+            android:background="@drawable/edt_bg_selector"
+            android:hint="현재 비밀번호"
+            android:paddingLeft="-12.5dp"
+            android:textColorHint="@color/input_hint"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintTextAppearance="@style/App.hintSmallTextAppearance"
+            app:hintTextColor="@color/input_label">
+
+            <!-- 비밀번호 입력 란 -->
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/current_password_editText"
+                android:layout_width="337.5dp"
+                android:layout_height="match_parent"
+                android:ellipsize="end"
+                android:inputType="textPassword|textNoSuggestions"
+                android:maxLength="20"
+                android:paddingTop="12dp"
+                android:textColor="@color/dark_grey"
+                android:textCursorDrawable="@drawable/cursor_color"
+                android:textSize="17.5sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 비밀번호 입력 TextInputLayout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_textInputLayout"
+            android:layout_width="325dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/current_password_textInputLayout"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="18.5dp"
+            android:background="@drawable/edt_bg_selector"
+            android:hint="비밀번호"
+            android:paddingLeft="-12.5dp"
+            android:textColorHint="@color/input_hint"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintTextAppearance="@style/App.hintSmallTextAppearance"
+            app:hintTextColor="@color/input_label">
+
+            <!-- 비밀번호 입력 란 -->
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password_editText"
+                android:layout_width="337.5dp"
+                android:layout_height="match_parent"
+                android:ellipsize="end"
+                android:inputType="textPassword|textNoSuggestions"
+                android:maxLength="20"
+                android:paddingTop="12dp"
+                android:textColor="@color/dark_grey"
+                android:textCursorDrawable="@drawable/cursor_color"
+                android:textSize="17.5sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 비밀번호 재확인 TextInputLayout -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/passwordConfirm_textInputLayout"
+            android:layout_width="325dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/password_textInputLayout"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="18.5dp"
+            android:background="@drawable/edt_bg_selector"
+            android:hint="비밀번호 재확인 "
+            android:paddingLeft="-12.5dp"
+            android:textColorHint="@color/input_hint"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintTextAppearance="@style/App.hintSmallTextAppearance"
+            app:hintTextColor="@color/input_label">
+
+            <!-- 비밀번호 재확인 입력 란 -->
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/passwordConfirm_editText"
+                android:layout_width="337.5dp"
+                android:layout_height="match_parent"
+                android:ellipsize="end"
+                android:inputType="textPassword|textNoSuggestions"
+                android:maxLength="20"
+                android:paddingTop="12dp"
+                android:textColor="@color/dark_grey"
+                android:textCursorDrawable="@drawable/cursor_color"
+                android:textSize="17.5sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </RelativeLayout>
+
+    <!-- 비밀번호 변경 버튼 -->
+    <Button
+        android:id="@+id/modify_complete_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="22.5dp"
+        android:backgroundTint="@color/blue"
+        android:letterSpacing="0"
+        android:outlineProvider="none"
+        android:paddingTop="17.5dp"
+        android:paddingBottom="17.5dp"
+        android:text="변경"
+        android:textColor="@color/white"
+        android:textSize="17.5sp"
+        app:cornerRadius="13dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_sign_up_step1.xml
+++ b/app/src/main/res/layout/activity_sign_up_step1.xml
@@ -95,6 +95,7 @@
                     android:layout_height="match_parent"
                     android:ellipsize="end"
                     android:inputType="textNoSuggestions"
+                    android:paddingTop="12dp"
                     android:textColor="@color/dark_grey"
                     android:textCursorDrawable="@drawable/cursor_color"
                     android:textSize="17.5sp" />

--- a/app/src/main/res/layout/dialog_modify_password_failed.xml
+++ b/app/src/main/res/layout/dialog_modify_password_failed.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="320dp"
+    android:layout_height="170dp"
+    android:layout_centerVertical="true"
+    android:layout_gravity="center"
+    android:background="@drawable/dialog_radius">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:letterSpacing="-0.025"
+        android:paddingLeft="20dp"
+        android:paddingTop="27.5dp"
+        android:text="@string/dialog_modify_password_failed"
+        android:textColor="@color/dark_grey"
+        android:textSize="20sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginLeft="15dp"
+        android:layout_marginRight="15dp"
+        android:layout_marginBottom="15dp">
+
+        <Button
+            android:id="@+id/yesBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="3.5dp"
+            android:layout_weight="1"
+            android:backgroundTint="@color/blue"
+            android:insetTop="2dp"
+            android:insetBottom="2dp"
+            android:outlineProvider="none"
+            android:text="닫기"
+            android:textSize="15sp"
+            app:cornerRadius="10dp" />
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_my_page_activity.xml
+++ b/app/src/main/res/layout/fragment_my_page_activity.xml
@@ -1,389 +1,238 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     android:clickable="true"
-    android:scrollbarFadeDuration="0"
-    android:scrollbarSize="5dp"
     tools:context=".sideBarMenu.myPage.MyPageFragment">
 
-    <!-- TODO: Update blank fragment layout -->
+    <!-- Root RelativeLayout -->
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white">
+        android:layout_height="match_parent">
 
-        <!-- 뒤로가기 버튼 -->
-        <ImageButton
-            android:id="@+id/back_ibtn"
-            android:layout_width="42.5dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="22dp"
-            android:layout_marginEnd="15dp"
-            android:layout_marginBottom="15dp"
-            android:backgroundTint="#FFFFFF"
-            android:src="@drawable/back" />
-
-        <!-- 마이페이지 메뉴명 -->
-        <TextView
-            android:id="@+id/menuTitle_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="41dp"
-            android:text="마이페이지"
-            android:textColor="@color/black"
-            android:textSize="21sp"
-            android:textStyle="bold" />
-
-        <!-- 가로 구분선 -->
-        <View
-            android:id="@+id/Under_Tline"
+        <!-- fragment (header) RelativeLayout -->
+        <RelativeLayout
+            android:id="@+id/fragment_header_relativeLayout"
             android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_alignBottom="@+id/menuTitle_tv"
-            android:layout_marginBottom="-18dp"
-            android:background="#BCBCBC" />
+            android:layout_height="wrap_content">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+            <!-- "뒤로가기" 버튼 -->
+            <ImageButton
+                android:id="@+id/back_iBtn"
+                android:layout_width="42.5dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="5dp"
+                android:layout_marginTop="10dp"
+                android:backgroundTint="@color/transparent"
+                android:src="@drawable/back"
+                tools:ignore="SpeakableTextPresentCheck" />
+
+            <!-- "~~~님의 정보" 메뉴명 -->
+            <TextView
+                android:id="@+id/my_page_fragment_title_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_marginTop="27.5dp"
+                android:letterSpacing="-0.01"
+                android:text="홍길동님의 정보"
+                android:textColor="@color/dark_grey"
+                android:textSize="17.5sp" />
+
+            <!-- "정보 수정" TextView -->
+            <TextView
+                android:id="@+id/modify_my_info_tv"
+                android:layout_width="60dp"
+                android:layout_height="50dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerInParent="true"
+                android:layout_marginTop="29dp"
+                android:layout_marginEnd="10dp"
+                android:gravity="center"
+                android:letterSpacing="-0.01"
+                android:text="수정"
+                android:textColor="@color/dark_grey"
+                android:textSize="16sp" />
+        </RelativeLayout>
+
+        <!-- fragment (body) RelativeLayout -->
+        <RelativeLayout
+            android:id="@+id/fragment_body_relativeLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_alignTop="@+id/Under_Tline"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentEnd="true"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/fragment_header_relativeLayout">
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp">
+
+                    <!-- "프로필 이미지" RelativeLayout -->
+                    <RelativeLayout
+                        android:id="@+id/userImage_relativeLayout"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true">
+
+                        <!-- 프로필 이미지 -->
+                        <com.makeramen.roundedimageview.RoundedImageView
+                            android:id="@+id/userImage_roundedImageView"
+                            android:layout_width="80dp"
+                            android:layout_height="80dp"
+                            android:layout_marginTop="10dp"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/default_profile_image"
+                            app:riv_oval="true" />
+
+                        <!-- 프로필 이미지 추가 이미지 배경(흰색) -->
+                        <com.makeramen.roundedimageview.RoundedImageView
+                            android:id="@+id/photoIcon_plus_background_roundedImageView"
+                            android:layout_width="35dp"
+                            android:layout_height="35dp"
+                            android:layout_marginStart="45dp"
+                            android:layout_marginTop="62.5dp"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/white_filled_circle"
+                            app:riv_oval="true" />
+
+                        <!-- 프로필 이미지 추가(플러스) 이미지 -->
+                        <com.makeramen.roundedimageview.RoundedImageView
+                            android:id="@+id/photoIcon_plus_roundedImageView"
+                            android:layout_width="25dp"
+                            android:layout_height="25dp"
+                            android:layout_marginStart="50.5dp"
+                            android:layout_marginTop="67.5dp"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/plus_circle"
+                            app:riv_oval="true" />
+                    </RelativeLayout>
+
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/userImage_relativeLayout"
+                        android:layout_marginTop="20dp">
+
+                        <RelativeLayout
+                            android:id="@+id/nickname_relativeLayout"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="25dp"
+                            android:paddingTop="20dp"
+                            android:paddingEnd="25dp"
+                            android:paddingBottom="20dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="이름"
+                                android:textColor="@color/text_blue"
+                                android:textSize="16.5sp" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentRight="true"
+                                android:text="홍길동"
+                                android:textSize="16.5sp" />
+                        </RelativeLayout>
+
+                        <RelativeLayout
+                            android:id="@+id/email_relativeLayout"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_below="@+id/nickname_relativeLayout"
+                            android:paddingStart="25dp"
+                            android:paddingTop="20dp"
+                            android:paddingEnd="25dp"
+                            android:paddingBottom="20dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="이메일 주소"
+                                android:textColor="@color/text_blue"
+                                android:textSize="16.5sp" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentRight="true"
+                                android:text="abc123@naver.com"
+                                android:textSize="16.5sp" />
+                        </RelativeLayout>
+
+                        <!-- 가로 구분선 -->
+                        <RelativeLayout
+                            android:id="@+id/dividing_line_relativeLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="17.5dp"
+                            android:layout_below="@+id/email_relativeLayout"
+                            android:layout_marginTop="5dp"
+                            android:layout_marginBottom="5dp"
+                            android:background="@color/bg_grey" />
+
+                        <RelativeLayout
+                            android:id="@+id/password_relativeLayout"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_below="@+id/dividing_line_relativeLayout"
+                            android:paddingStart="25dp"
+                            android:paddingTop="20dp"
+                            android:paddingEnd="12.5dp"
+                            android:paddingBottom="20dp">
+
+                            <TextView
+                                android:id="@+id/modify_password_tv"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="비밀번호 변경"
+                                android:textColor="@color/text_blue"
+                                android:textSize="16.5sp" />
+
+                            <!-- 우측 화살표 버튼 -->
+                            <ImageButton
+                                android:id="@+id/in_iBtn"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentRight="true"
+                                android:layout_marginStart="-7.5dp"
+                                android:layout_marginTop="-4dp"
+                                android:backgroundTint="@color/transparent"
+                                android:foregroundTint="@color/white"
+                                android:src="@drawable/arrow_right_grey" />
+                        </RelativeLayout>
+                    </RelativeLayout>
+                </RelativeLayout>
+            </ScrollView>
+        </RelativeLayout>
+
+        <!-- 비밀번호 변경 버튼 -->
+        <Button
+            android:id="@+id/modify_complete_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:layout_marginStart="0dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginEnd="0dp"
-            android:layout_marginBottom="0dp">
-
-            <ImageButton
-                android:id="@+id/imageButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="100dp"
-                android:background="@color/white"
-                android:src="@drawable/profile_img"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.126"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/textView2"
-                android:layout_width="184dp"
-                android:layout_height="45dp"
-                android:layout_gravity="center"
-                android:gravity="center"
-                android:text="기본 정보 수정"
-                android:textColor="@color/black"
-                android:textSize="25sp"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toTopOf="@+id/imageButton"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.136"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.285" />
-
-            <TextView
-                android:id="@+id/textView3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginBottom="10dp"
-                android:text="프로필 이미지"
-                android:textSize="20sp"
-                app:layout_constraintBottom_toTopOf="@+id/imageButton"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.143"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView2"
-                app:layout_constraintVertical_bias="0.0" />
-
-
-            <TextView
-                android:id="@+id/textView5"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="성"
-                android:textColor="@color/black"
-                android:textSize="23dp"
-                app:layout_constraintBottom_toTopOf="@+id/Mypage_input_first_name"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.108"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageButton"
-                app:layout_constraintVertical_bias="0.482" />
-            <!-- first name 입력 -->
-            <EditText
-                android:id="@+id/Mypage_input_first_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginTop="48dp"
-                android:background="@drawable/mypage_input_sky"
-                android:gravity="left"
-                android:text="  여기에 성을 입력해주세요."
-                app:layout_constraintBottom_toTopOf="@+id/under_Tline"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.521"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageButton"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <!-- last name 입력 -->
-
-            <!-- Account name 표시-->
-
-
-            <TextView
-                android:id="@+id/textView7"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="이름"
-                android:textColor="@color/black"
-                android:textSize="23dp"
-                app:layout_constraintBottom_toTopOf="@+id/Mypage_input_lastname"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.106"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/Mypage_input_first_name"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <EditText
-                android:id="@+id/Mypage_input_lastname"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:background="@drawable/mypage_input_sky"
-                android:gravity="left"
-                android:text="  여기에 이름을 입력해주세요."
-                app:layout_constraintBottom_toTopOf="@+id/Mypage_Account_name"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.521"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/Mypage_input_first_name" />
-
-            <TextView
-                android:id="@+id/textView9"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="아이디"
-                android:textSize="23dp"
-                app:layout_constraintBottom_toTopOf="@+id/Mypage_Account_name"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.128"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/Mypage_input_lastname"
-                app:layout_constraintVertical_bias="0.566" />
-
-            <TextView
-                android:id="@+id/Mypage_Account_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginTop="112dp"
-                android:background="@drawable/mypage_input_gray"
-                android:gravity="left"
-                android:text="  bravekid56"
-                android:textColor="@color/black"
-                android:textSize="20dp"
-                app:layout_constraintBottom_toTopOf="@+id/under_Tline"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.521"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/Mypage_input_first_name"
-                app:layout_constraintVertical_bias="0.0" />
-            <!-- 줄나누기 -->
-
-            <!--Logininfo -->
-
-            <View
-                android:id="@+id/under_Tline"
-                android:layout_width="350sp"
-                android:layout_height="1dp"
-                android:layout_gravity="center"
-                android:layout_marginTop="432dp"
-                android:background="#BCBCBC"
-                android:gravity="center"
-                app:layout_constraintBottom_toTopOf="@+id/textView6"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.508"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <View
-                android:id="@+id/under_Tline2"
-                android:layout_width="350sp"
-                android:layout_height="1dp"
-                android:layout_gravity="center"
-                android:layout_marginTop="96dp"
-                android:background="#BCBCBC"
-                android:gravity="center"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/editTextTextEmailAddress"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <TextView
-                android:id="@+id/textView6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="292dp"
-                android:text="로그인 정보"
-                android:textColor="@color/black"
-                android:textSize="23dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.087"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageButton" />
-
-            <EditText
-                android:id="@+id/editTextTextEmailAddress"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="36dp"
-                android:background="@drawable/mypage_input_gray"
-                android:ems="10"
-                android:inputType="textEmailAddress"
-                app:layout_constraintBottom_toTopOf="@+id/editTextTextPassword"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView6"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <TextView
-                android:id="@+id/textView8"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="이메일 주소"
-                android:textSize="20sp"
-                app:layout_constraintBottom_toTopOf="@+id/editTextTextEmailAddress"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.129"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView6"
-                app:layout_constraintVertical_bias="1.0" />
-
-            <TextView
-                android:id="@+id/textView10"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="비밀번호"
-                android:textSize="20sp"
-                app:layout_constraintBottom_toTopOf="@+id/editTextTextPassword"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.114"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/editTextTextEmailAddress"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <EditText
-                android:id="@+id/editTextTextPassword"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="88dp"
-                android:background="@drawable/mypage_input_gray"
-                android:ems="10"
-                android:inputType="textPassword"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView6"
-                app:layout_constraintVertical_bias="0.053" />
-            <!--Verification 인증  -->
-
-            <TextView
-                android:id="@+id/textView11"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="인증정보"
-                android:textColor="@color/black"
-                android:textSize="23dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.122"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/under_Tline2"
-                app:layout_constraintVertical_bias="0.273" />
-
-            <ImageView
-                android:id="@+id/imageView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:src="@drawable/mypage_img_mail"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.094"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView11"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <!-- 이메일 인증 설정 표시 이미지 -->
-            <TextView
-                android:id="@+id/textView12"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="이메일 인증 "
-                android:textSize="15dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.229"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView11"
-                app:layout_constraintVertical_bias="0.165" />
-
-            <ImageView
-                android:id="@+id/imageView4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@color/white"
-                android:src="@drawable/disenable_imgbtn"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.727"
-                app:layout_constraintStart_toEndOf="@+id/textView11"
-                app:layout_constraintTop_toBottomOf="@+id/under_Tline2"
-                app:layout_constraintVertical_bias="0.561" />
-            <!-- 이메일 인증 제거 버튼 -->
-
-
-            <ImageButton
-                android:id="@+id/imageButton3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:background="@color/white"
-                android:src="@drawable/mypage_remove_mail_imgbtn"
-                app:layout_constraintBottom_toTopOf="@+id/imageButton4"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.158"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/textView12"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <ImageButton
-                android:id="@+id/imageButton4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@color/white"
-                android:src="@drawable/mypage_update_imgbtn"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.53"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageView4"
-                app:layout_constraintVertical_bias="1.0" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
+            android:layout_centerHorizontal="true"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="22.5dp"
+            android:backgroundTint="@color/blue"
+            android:letterSpacing="0"
+            android:outlineProvider="none"
+            android:paddingTop="17.5dp"
+            android:paddingBottom="17.5dp"
+            android:text="이미지 변경"
+            android:textColor="@color/white"
+            android:textSize="17.5sp"
+            android:visibility="invisible"
+            app:cornerRadius="13dp" />
     </RelativeLayout>
-</ScrollView>
+</FrameLayout>

--- a/app/src/main/res/layout/toast_modify_success.xml
+++ b/app/src/main/res/layout/toast_modify_success.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardBackgroundColor="@color/toast_bg"
+    app:cardCornerRadius="30dp">
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="52.5dp"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <RelativeLayout
+            android:id="@+id/check_circle_image_relativeLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true">
+
+            <!-- 프로필 이미지 추가 이미지 배경(흰색) -->
+            <com.makeramen.roundedimageview.RoundedImageView
+                android:id="@+id/photoIcon_plus_background_roundedImageView"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/white_filled_circle"
+                app:riv_oval="true" />
+
+            <!-- 프로필 이미지 추가 이미지 배경(흰색) -->
+            <com.makeramen.roundedimageview.RoundedImageView
+                android:id="@+id/check_circle_roundedImageView"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/check_circle"
+                app:riv_oval="true" />
+
+        </RelativeLayout>
+
+        <TextView
+            android:id="@+id/toast_modify_success_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginStart="9dp"
+            android:layout_toRightOf="@+id/check_circle_image_relativeLayout"
+            android:text=""
+            android:textColor="@color/white"
+            android:textSize="17.5sp" />
+
+    </RelativeLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,6 +24,8 @@
     <color name="input_label">#8e949f</color>
     <color name="input_hint">#afb8c1</color>
     <color name="bg_grey">#f2f3f5</color>
+    <color name="toast_bg">#888F9B</color>
+    <color name="light_green">#59bd83</color>
 
     <color name="colorPrimary">#6200EE</color>
     <color name="colorPrimaryDark">#3700B3</color>

--- a/app/src/main/res/values/string_account.xml
+++ b/app/src/main/res/values/string_account.xml
@@ -50,6 +50,7 @@
     <string name="dialog_modify_password_successs">비밀번호가 정상적으로\n변경되었습니다</string>
 
     <!-- Strings related to (Toast) -->
+    <string name="toast_modify_user_image_success">이미지를 변경했어요 😀</string>
     <string name="toast_modify_my_info_success">회원정보를 수정했어요</string>
     <string name="toast_modify_password_success">비밀번호를 변경했어요</string>
 

--- a/app/src/main/res/values/string_account.xml
+++ b/app/src/main/res/values/string_account.xml
@@ -14,6 +14,7 @@
     <string name="sign_up_error_email">이메일을 정확하게 입력해주세요</string>
     <string name="sign_up_email_confirm_success">사용 가능한 이메일입니다</string>
     <string name="sign_up_email_confirm_failed">이미 사용 중인 이메일입니다</string>
+    <string name="sign_up_step1_current_password_validation_failed">현재 비밀번호와 일치하지 않습니다</string>
     <string name="sign_up_step1_password_validation_failed">비밀번호 입력을 완료해 주세요</string>
     <string name="sign_up_step1_password_confirm_validation_failed">비밀번호가 일치하지 않습니다</string>
     <string name="sign_up_error_name">이름은 2글자 이상의 한글만 가능합니다</string>
@@ -36,10 +37,20 @@
     <string name="find_change_success">비밀번호 변경에 성공하였습니다.</string>
     <string name="find_change_failed">비밀번호 변경에 실패하였습니다</string>
 
-    <!-- Strings related to (Dialog)) -->
+    <string name="current_and_new_password_same">현재와 동일한 비밀번호는 사용하실 수 없습니다</string>
+
+
+    <!-- Strings related to (Dialog) -->
     <string name="dialog_place_remove">장소를 삭제할까요?</string>
     <string name="dialog_ask_user_default_profile_image">기본 프로필 이미지를\n사용하시겠습니까? 😀</string>
     <string name="dialog_find_email_success">해당 이메일로 임시 비밀번호가\n발송되었습니다 📮</string>
     <string name="dialog_sign_up_success">회원가입이 완료되었습니다.\n로그인 페이지로 이동합니다 🥳</string>
+    <string name="dialog_modify_my_info_complete_success">회원정보를 정상적으로\n수정하였습니다</string>
+    <string name="dialog_modify_password_failed">비밀번호를 정확하게\n입력해주세요</string>
+    <string name="dialog_modify_password_successs">비밀번호가 정상적으로\n변경되었습니다</string>
+
+    <!-- Strings related to (Toast) -->
+    <string name="toast_modify_my_info_success">회원정보를 수정했어요</string>
+    <string name="toast_modify_password_success">비밀번호를 변경했어요</string>
 
 </resources>


### PR DESCRIPTION
## 👀 이슈

resolve #60 

## 📌 개요

프로젝트 초기 `Figma`에서 `마이페이지` UI를 디자인을 했을 당시
현재 회원가입에서 요구되는 요소와 차이가 있었고, 좀 더 완성도 있는
UI 구성을 위해 기존 UI를 수정하였습니다.

## 👩‍💻 작업 사항

- Sidebar Navigation 내 `마이페이지` 메뉴 fragment UI 수정
- `비밀번호 변경` 액티비티`, `정보 수정` 액티비티 추가

## ✅ 참고 사항

- 이전 `마이페이지` fragment 디자인

![ezgif com-resize (6)](https://user-images.githubusercontent.com/56868605/221517793-125869d7-c9a0-438a-b4db-c03ed8053064.gif)

- 작업 후 `마이페이지` 관련 UI

![1](https://user-images.githubusercontent.com/56868605/222127150-8685ae8c-bf10-401d-823c-b789953ad0cd.gif)

![ezgif com-resize (9)](https://user-images.githubusercontent.com/56868605/222127649-d09fc8e3-5ac8-4954-92e8-4b783bcbb4d2.gif)