### PR TITLE
[bug]: 회원가입 단계(2) 액티비티 내 '닉네임' 입력 란 검증 로직 버그 제거 (#68)

### DIFF
--- a/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep2Activity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/SignUpStep2Activity.java
@@ -82,7 +82,7 @@ public class SignUpStep2Activity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 // 입력 란 검증 실패 및 공란 확인 조건식
-                if (String.valueOf(binding.nicknameEditText.getText()).equals("")) {
+                if (binding.nicknameTextInputLayout.getError() != null || String.valueOf(binding.nicknameEditText.getText()).equals("")) {
                     binding.nicknameEditText.requestFocus();
                     binding.nicknameTextInputLayout.setError(getResources().getString(R.string.sign_up_nickname_failed));
                     binding.nicknameTextInputLayout.setErrorEnabled(true);


### PR DESCRIPTION
## 👀 이슈

resolve #68 

## 📌 개요

현재 애플리케이션 내 회원가입 2단계에 있는 `닉네임 입력 란`의 규칙은
한/영 문자 및 숫자 등으로 2~10글자로 작성되도록 로직이 설정되어 있는데,
1글자 입력 후 `회원가입` 버튼을 클릭하였을 때 정상적으로 회원가입이 진행되는
이슈가 있어 해당 버그를 제거하고자 하였습니다.

## 👩‍💻 작업 사항

- 회원가입 2단계 액티비티를 제어하는 `SignUpStep2Activity.java` 파일 수정

## ✅ 참고 사항

- 해당 버그

![ezgif com-resize (14)](https://user-images.githubusercontent.com/56868605/224610419-f9d53469-857e-45a4-bc76-8015606107d0.gif)

- 버그 제거 후

![ezgif com-resize (17)](https://user-images.githubusercontent.com/56868605/224615578-b9ae0260-80b7-4692-989e-98c3957e2b2e.gif)