### PR TITLE
[bug]: 장소 정보 수정 시 장소 목록에 장소 정보 item이 추가되는 버그 제거 및 장소 정보 등록/수정 시 안내 ToastMessage 추가 (#70)

### DIFF
--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.textfield.TextInputEditText;
 import com.project.sinabro.R;
 import com.project.sinabro.toast.ToastSuccess;
+import com.project.sinabro.toast.ToastWarning;
 
 public class AddLocationInfoActivity extends AppCompatActivity {
 
@@ -66,10 +67,18 @@ public class AddLocationInfoActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);
-                if (placeName_editText.getText().toString().equals("") || detailAddress_editText.getText().toString().equals("")) {
-                    intent.putExtra("input_value", false);
+                Boolean forModify = getIntent().getBooleanExtra("forModify", false);
+                if (forModify) {
+                    placeRemove_dialog.dismiss(); // 다이얼로그 닫기
+                    new ToastSuccess(getResources().getString(R.string.toast_modify_list_success), AddLocationInfoActivity.this);
                     startActivity(intent);
+                    return;
+                }
+
+                if (placeName_editText.getText().toString().equals("") || detailAddress_editText.getText().toString().equals("")) {
+                    new ToastWarning(getResources().getString(R.string.toast_add_place_failed), AddLocationInfoActivity.this);
                 } else {
+                    new ToastSuccess(getResources().getString(R.string.toast_add_place_success), AddLocationInfoActivity.this);
                     intent.putExtra("input_value", true);
                     intent.putExtra("placeName_value", placeName_editText.getText().toString());
                     intent.putExtra("detailAddress_value", detailAddress_editText.getText().toString());

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
@@ -89,7 +89,6 @@ public class PlaceListActivity extends AppCompatActivity {
         adapter.addItem(new PlaceItem("가나다라마바  사아자차카타하", "205호", -1));
         adapter.addItem(new PlaceItem("샘마루(SAMMaru)", "113호", -1));
         adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "205호", -1));
-        adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "203호", -1));
 
         final Intent intent = getIntent();
         Boolean input_value = intent.getBooleanExtra("input_value", false);
@@ -222,11 +221,10 @@ public class PlaceListActivity extends AppCompatActivity {
             public void onClick(View view) {
                 placeInfo_dialog.dismiss(); // 다이얼로그 닫기
                 final Intent intent = new Intent(getApplicationContext(), AddLocationInfoActivity.class);
-
                 intent.putExtra("modify_clicked", true);
+                intent.putExtra("forModify", true);
                 intent.putExtra("placeName_value", placeName_tv_inDialog.getText().toString());
                 intent.putExtra("detailAddress_value", detailAddress_tv_inDialog.getText().toString());
-
                 startActivity(intent);
             }
         });

--- a/app/src/main/res/values/string_account.xml
+++ b/app/src/main/res/values/string_account.xml
@@ -65,6 +65,8 @@
     <string name="toast_remove_list_failed">선택된 리스트가 없어요</string>
     <string name="toast_add_list_success">리스트를 추가했어요</string>
     <string name="toast_modify_list_success">정보를 수정했어요</string>
+    <string name="toast_add_place_success">정보를 추가했어요</string>
+    <string name="toast_add_place_failed">정보를 모두 입력해 주세요</string>
     <string name="toast_add_list_failed">리스트 색상이 필요해요</string>
     <string name="toast_select_color_failed">색상 선택이 필요해요</string>
 


### PR DESCRIPTION
## 👀 이슈

resolve #70 

## 📌 개요

현재 `MainActivity` 내에서 지도 클릭 후 해당 위치에 등록된 여러 세부 장소 정보가 담겨 있는
리스트에 접근할 수 있는데, 이 리스트 내 세부 장소의 정보를 수정한 후 `수정하기` 버튼을
클릭하면, 세부 장소 정보 리스트에 새로운 `item`이 추가되는 버그가 발견되어 해당 문제를
해결하고자 하였습니다.
> 추가적으로, `장소 등록/수정` 시 작업 완료 여부를 시각적으로 빠르게 확인할 수 있도록
관련 안내 ToastMessage를 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `장소 정보 추가/수정`, `등록된 세부 장소 정보 리스트` 액티비티 제어 자바 파일 내 구분점 로직 추가
- 문자열 관리 파일 내 ToastMessage 전용 string value 추가

## ✅ 참고 사항

- 해당 버그

![ezgif com-resize (20)](https://user-images.githubusercontent.com/56868605/225372285-34489979-84e2-44e6-be15-f568c1acfeed.gif)

- 버그 제거 및 세부장소 등록/수정 안내 ToastMessage 추가 후

![ezgif com-resize (21)](https://user-images.githubusercontent.com/56868605/225520106-4667f2d1-f7c0-457e-b48d-aeee4e3c5691.gif)

- 세부 장소 등록 시 입력 란을 공란인 상태로 등록을 시도하는 경우 안내 ToastMessage 추가

![ezgif com-resize (21)](https://user-images.githubusercontent.com/56868605/225526941-0054c65a-ef7e-400f-9534-570a28328db4.gif)