### PR TITLE
[feat]: 카카오맵 마커 내 인원수 표시 UI 추가 (#77)

### DIFF
--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.widget.Button;
@@ -42,7 +43,7 @@ public class AddLocationInfoActivity extends AppCompatActivity {
         });
 
         final Intent intent = getIntent();
-        Boolean modify_clicked = intent.getBooleanExtra("modify_clicked", false);
+        Boolean forModify = intent.getBooleanExtra("forModify", false);
 
         placeRemove_dialog = new Dialog(AddLocationInfoActivity.this);  // Dialog 초기화
         placeRemove_dialog.requestWindowFeature(Window.FEATURE_NO_TITLE); // 타이틀 제거
@@ -51,7 +52,7 @@ public class AddLocationInfoActivity extends AppCompatActivity {
         placeRemove_dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
 
         placeRemove_tv = findViewById(R.id.placeRemove_tv);
-        if (modify_clicked) placeRemove_tv.setVisibility(View.VISIBLE);
+        if (forModify) placeRemove_tv.setVisibility(View.VISIBLE);
         placeRemove_tv.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -67,7 +68,6 @@ public class AddLocationInfoActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);
-                Boolean forModify = getIntent().getBooleanExtra("forModify", false);
                 if (forModify) {
                     placeRemove_dialog.dismiss(); // 다이얼로그 닫기
                     new ToastSuccess(getResources().getString(R.string.toast_modify_list_success), AddLocationInfoActivity.this);
@@ -87,7 +87,7 @@ public class AddLocationInfoActivity extends AppCompatActivity {
             }
         });
 
-        if (modify_clicked) {
+        if (forModify) {
             String placeName_value = intent.getStringExtra("placeName_value");
             String detailAddress_value = intent.getStringExtra("detailAddress_value");
 

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -221,7 +222,6 @@ public class PlaceListActivity extends AppCompatActivity {
             public void onClick(View view) {
                 placeInfo_dialog.dismiss(); // 다이얼로그 닫기
                 final Intent intent = new Intent(getApplicationContext(), AddLocationInfoActivity.class);
-                intent.putExtra("modify_clicked", true);
                 intent.putExtra("forModify", true);
                 intent.putExtra("placeName_value", placeName_tv_inDialog.getText().toString());
                 intent.putExtra("detailAddress_value", detailAddress_tv_inDialog.getText().toString());

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -53,11 +53,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_marginTop="45dp"
-        android:layout_marginEnd="3dp"
+        android:layout_marginEnd="5dp"
         android:gravity="center"
         android:text="?"
-        android:textSize="50sp"
-        android:textStyle="bold" />
+        android:textSize="40sp"
+         />
 
     <!-- 밀집도 정도(미등록 시: 없음) -->
     <TextView
@@ -66,11 +66,11 @@
         android:layout_height="30dp"
         android:layout_below="@+id/peopleCount_tv"
         android:layout_alignParentRight="true"
-        android:layout_marginTop="-12.5dp"
+        android:layout_marginTop="-5dp"
         android:layout_marginEnd="29.5dp"
         android:gravity="center"
         android:text="정보 없음"
-        android:textSize="10sp"
+        android:textSize="12.5sp"
         android:textStyle="bold" />
 
     <RelativeLayout
@@ -166,7 +166,7 @@
         android:layout_height="32.5dp"
         android:layout_below="@+id/peopleCount_tv"
         android:layout_alignParentRight="true"
-        android:layout_marginTop="7.5dp"
+        android:layout_marginTop="17.5dp"
         android:layout_marginEnd="24dp"
         android:layout_marginRight="20dp"
         android:layout_marginBottom="22.5dp"


### PR DESCRIPTION
## 👀 이슈

resolve #77 

## 📌 개요

지도 내 특정 위치에 인원수 정보가 등록되어 있는 경우, 해당 마커 중앙에
인원수 정보가 표시되어 나타나도록 UI를 구성하였습니다.

## 👩‍💻 작업 사항

- 특정 장소 3곳에 대한 마커 정보 추가(소프트웨어학부 `102호` 및 `106호`, 자연대5호관 `123호`)
- 기존에 등록된 마커 클릭 시 해당 장소의 인원수 표시 UI 추가
- 기존에 등록된 마커 클릭 후 `장소 정보추가/수정` 버튼 클릭 시 정보 수정 가능

## ✅ 참고 사항

- 이전 마커 디자인

<img width="152" alt="Screenshot 2023-04-08 at 12 02 20 PM" src="https://user-images.githubusercontent.com/56868605/230700491-f1f289fc-6e99-4dca-ba5a-e568f70f84c3.png">

- 기능 추가 후 마커

![ezgif com-video-to-gif (17)](https://user-images.githubusercontent.com/56868605/232008405-cadca3b2-abb6-4ebd-9a8a-df4a206c0401.gif)