### PR TITLE
[fix]: 서버 APIs 루트 엔드포인트 변경으로 인한 클라이언트 측 통신용 인터페이스 내 엔드포인트 주소 일괄 변경 (#84)

### DIFF
--- a/app/src/main/java/com/project/sinabro/retrofit/PeopleNumbersAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/PeopleNumbersAPI.java
@@ -13,12 +13,12 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface PeopleNumbersAPI {
-    @GET("/peopleNumbers/placeInformations")
+    @GET("/api/peopleNumbers/placeInformations")
     Call<List<PeopleNumber>> getPlaceInformations();
 
-    @GET("/peopleNumbers/{id}/placeInformations")
+    @GET("/api/peopleNumbers/{id}/placeInformations")
     Call<List<PeopleNumber>> getPlaceInformationsById(@Path("id") String id);
 
-    @POST("/peopleNumbers")
+    @POST("/api/peopleNumbers")
     Call<Place> addPeopleNumber(@Body PeopleNumber peopleNumber);
 }

--- a/app/src/main/java/com/project/sinabro/retrofit/PlacesAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/PlacesAPI.java
@@ -13,15 +13,15 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface PlacesAPI {
-    @GET("/places")
+    @GET("/api/places")
     Call<List<Place>> getPlaces();
 
-    @POST("/places")
+    @POST("/api/places")
     Call<Place> addPlaceInformation(@Body Place place);
 
-    @PATCH("/places/{id}")
+    @PATCH("/api/places/{id}")
     Call<Place> updatePlace(@Path("id") String id, @Body Place place);
 
-    @DELETE("/places/{id}")
+    @DELETE("/api/places/{id}")
     Call<Integer> deletePlace(@Path("id") String id);
 }


### PR DESCRIPTION
## 👀 이슈

resolve #84 

## 📌 개요

기존 서버 측에 개발된 APIs에 대한 루트 엔드포인트 변경으로 인하여 클라이언트 측
서버 간 통신용 인터페이스 내 엔드포인트 주소의 일괄적으로 변경하였습니다.

## 👩‍💻 작업 사항

- `PeopleNumbersAPI.java` 인터페이스 내 APIs path 주소 변경
- `PlacesAPI.java` 인터페이스 내 APIs path 주소 변경

## ✅ 참고 사항

없습니다
