### PR TITLE
[fix]: 비밀번호 입력란 최소 입력 허용 글자수 에러 수정 (#110)

### DIFF
--- a/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
+++ b/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
@@ -64,7 +64,7 @@ public class PasswordWatcher implements TextWatcher {
     }
 
     public boolean validatePassword(String s) {
-        String passwordPattern = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&]).{8,20}.$";
+        String passwordPattern = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&]).{7,20}.$";
         return s.matches(passwordPattern);
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #110 

## 📌 개요

현재 애플리케이션 내에서 `비밀번호 입력란`으로 사용 중인 `TextInputEditText` 요소에
대하여 텍스트를 입력하게 되면, 최소 9글자를 입력하였을 때부터 비밀번호 글자수 검증 단계를
통과하게 되는데, 처음 회원가입을 할 때에 비밀번호는 8~20글자로 제한하고 있기에 8글자에
대한 비밀번호 입력 시 검증 실패가 되는 문제가 있어 해당 부분을 수정하였습니다.

## 👩‍💻 작업 사항

- `PasswordWatcher` 클래스 내 `passwordPattern` 정규식 수정

## ✅ 참고 사항

- `passwordPattern` 정규식 수정 이전
> 8글자에 대한 입력은 비밀번호 검증 단계 실패로 처리되는 문제가 있음

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/af94aa5d-bb70-4aef-9f63-02fbbc7e6c13

---

- `passwordPattern` 정규식 수정 이후
> 8글자 입력 시 비밀번호 검증 단계가 정상적으로 통과됨

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/3c610f32-3275-401f-b7ae-4f1df7e13e6a