### PR TITLE
[fix]: Bottom Sheet 레이아웃 관련 액티비티 내부 APIs 호출 코드 내 로그인 시간 만료에 대한 예외 처리 코드 추가 (#112)

### DIFF
--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -69,6 +69,7 @@ import com.project.sinabro.retrofit.RetrofitServiceForKakao;
 import com.project.sinabro.retrofit.UserAPI;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
 import com.project.sinabro.sideBarMenu.settings.CheckPasswordActivity;
+import com.project.sinabro.sideBarMenu.settings.MyPageActivity;
 import com.project.sinabro.toast.ToastWarning;
 import com.project.sinabro.utils.TokenManager;
 
@@ -500,12 +501,6 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                 CoordinateToAddress.Document document = documents.get(0);
                                 CoordinateToAddress.RoadAddress roadAddress = document.getRoadAddress();
 
-                                if (addedPlaceInfoState.equals("0")) {
-                                    final Intent intent = new Intent(MainActivity.this, AddPlaceGuideActivity.class);
-                                    startActivity(intent);
-                                    return;
-                                }
-
                                 Call<ResponseBody> call_userAPI_getUserSelfInfo = userAPI.getUserSelfInfo();
                                 call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
                                     @Override
@@ -514,6 +509,12 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                             try {
                                                 JSONObject jsonObject = new JSONObject(response.body().string());
                                                 tokenManager.saveUserInfo(jsonObject);
+
+                                                if (addedPlaceInfoState.equals("0")) {
+                                                    final Intent intent = new Intent(MainActivity.this, AddPlaceGuideActivity.class);
+                                                    startActivity(intent);
+                                                    return;
+                                                }
 
                                                 // 이곳에 카메라 촬영으로 이어지는 코드가 추가하면 됩니다.
                                                 finish();
@@ -549,8 +550,8 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
 
                     @Override
                     public void onFailure(Call<CoordinateToAddress> call, Throwable t) {
-                        Toast.makeText(MainActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
-                        Logger.getLogger(AddLocationInfoActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
                     }
                 });
             }
@@ -650,8 +651,8 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
 
                     @Override
                     public void onFailure(Call<CoordinateToAddress> call, Throwable t) {
-                        Toast.makeText(MainActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
-                        Logger.getLogger(AddLocationInfoActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
                     }
                 });
             }
@@ -726,8 +727,8 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
 
                     @Override
                     public void onFailure(Call<CoordinateToAddress> call, Throwable t) {
-                        Toast.makeText(MainActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
-                        Logger.getLogger(AddLocationInfoActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
                     }
                 });
             }
@@ -802,8 +803,8 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
 
                     @Override
                     public void onFailure(Call<CoordinateToAddress> call, Throwable t) {
-                        Toast.makeText(MainActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
-                        Logger.getLogger(AddLocationInfoActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
                     }
                 });
             }

--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -505,10 +505,41 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                     startActivity(intent);
                                     return;
                                 }
-                                // 이곳에 카메라 촬영으로 이어지는 코드가 추가하면 됩니다.
-                                finish();
-                                final Intent intent = new Intent(MainActivity.this, ObjectDetectionActivity.class);
-                                startActivity(intent);
+
+                                Call<ResponseBody> call_userAPI_getUserSelfInfo = userAPI.getUserSelfInfo();
+                                call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
+                                    @Override
+                                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                                        if (response.isSuccessful()) {
+                                            try {
+                                                JSONObject jsonObject = new JSONObject(response.body().string());
+                                                tokenManager.saveUserInfo(jsonObject);
+
+                                                // 이곳에 카메라 촬영으로 이어지는 코드가 추가하면 됩니다.
+                                                finish();
+                                                final Intent intent = new Intent(MainActivity.this, ObjectDetectionActivity.class);
+                                                startActivity(intent);
+                                            } catch (JSONException | IOException e) {
+                                                e.printStackTrace();
+                                            }
+                                        } else {
+                                            switch (response.code()) {
+                                                case 401:
+                                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                                    startActivity(intent);
+                                                    break;
+                                                default:
+                                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), MainActivity.this);
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
+                                    }
+                                });
                             } else {
                                 new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
                                 return;
@@ -579,7 +610,37 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                 intent.putExtra("detailAddress_value", selectedDetailAddress);
                                 intent.putExtra("placeId_value", selectedPlaceId);
                                 intent.putExtra("markerId_value", selectedMarkerId);
-                                startActivity(intent);
+
+                                Call<ResponseBody> call_userAPI_getUserSelfInfo = userAPI.getUserSelfInfo();
+                                call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
+                                    @Override
+                                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                                        if (response.isSuccessful()) {
+                                            try {
+                                                JSONObject jsonObject = new JSONObject(response.body().string());
+                                                tokenManager.saveUserInfo(jsonObject);
+                                                startActivity(intent);
+                                            } catch (JSONException | IOException e) {
+                                                e.printStackTrace();
+                                            }
+                                        } else {
+                                            switch (response.code()) {
+                                                case 401:
+                                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                                    startActivity(intent);
+                                                    break;
+                                                default:
+                                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), MainActivity.this);
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
+                                    }
+                                });
                             } else {
                                 new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
                                 return;
@@ -624,7 +685,38 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                             if (!documents.isEmpty()) {
                                 CoordinateToAddress.Document document = documents.get(0);
                                 CoordinateToAddress.RoadAddress roadAddress = document.getRoadAddress();
-                                showDialog_ask_add_or_delete_bookmark();
+
+                                Call<ResponseBody> call_userAPI_getUserSelfInfo = userAPI.getUserSelfInfo();
+                                call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
+                                    @Override
+                                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                                        if (response.isSuccessful()) {
+                                            try {
+                                                JSONObject jsonObject = new JSONObject(response.body().string());
+                                                tokenManager.saveUserInfo(jsonObject);
+
+                                                showDialog_ask_add_or_delete_bookmark();
+                                            } catch (JSONException | IOException e) {
+                                                e.printStackTrace();
+                                            }
+                                        } else {
+                                            switch (response.code()) {
+                                                case 401:
+                                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                                    startActivity(intent);
+                                                    break;
+                                                default:
+                                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), MainActivity.this);
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
+                                    }
+                                });
                             } else {
                                 new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
                                 return;
@@ -648,7 +740,72 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
         bookmarkFilled_btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                showDialog_ask_add_or_delete_bookmark();
+                Double latitude = Double.parseDouble("" + selectedLatitude);
+                Double longitude = Double.parseDouble("" + selectedLongitude);
+
+                // 위도와 경도가 한국 범위를 벗어났을 때
+                if (latitude <= 33.0 || latitude >= 38.0 || longitude <= 124.0 || longitude >= 132.0) {
+                    new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
+                    return;
+                }
+
+                RetrofitServiceForKakao retrofitServiceForKakao = new RetrofitServiceForKakao();
+                KakaoAPI kakaoInterface = retrofitServiceForKakao.getRetrofit().create(KakaoAPI.class);
+                Call<CoordinateToAddress> call = kakaoInterface.getAddress("WGS84", longitude, latitude);
+                call.enqueue(new Callback<CoordinateToAddress>() {
+                    @Override
+                    public void onResponse(Call<CoordinateToAddress> call, Response<CoordinateToAddress> response) {
+                        if (response.isSuccessful()) {
+                            CoordinateToAddress responseData = response.body();
+                            List<CoordinateToAddress.Document> documents = responseData.getDocuments();
+                            if (!documents.isEmpty()) {
+                                CoordinateToAddress.Document document = documents.get(0);
+                                CoordinateToAddress.RoadAddress roadAddress = document.getRoadAddress();
+
+                                Call<ResponseBody> call_userAPI_getUserSelfInfo = userAPI.getUserSelfInfo();
+                                call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
+                                    @Override
+                                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                                        if (response.isSuccessful()) {
+                                            try {
+                                                JSONObject jsonObject = new JSONObject(response.body().string());
+                                                tokenManager.saveUserInfo(jsonObject);
+
+                                                showDialog_ask_add_or_delete_bookmark();
+                                            } catch (JSONException | IOException e) {
+                                                e.printStackTrace();
+                                            }
+                                        } else {
+                                            switch (response.code()) {
+                                                case 401:
+                                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                                    startActivity(intent);
+                                                    break;
+                                                default:
+                                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), MainActivity.this);
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
+                                    }
+                                });
+                            } else {
+                                new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
+                                return;
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<CoordinateToAddress> call, Throwable t) {
+                        Toast.makeText(MainActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
+                        Logger.getLogger(AddLocationInfoActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                    }
+                });
             }
         });
 

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/AddLocationInfoActivity.java
@@ -20,6 +20,8 @@ import com.project.sinabro.R;
 import com.project.sinabro.models.Place;
 import com.project.sinabro.retrofit.PlacesAPI;
 import com.project.sinabro.retrofit.RetrofitService;
+import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
+import com.project.sinabro.sideBarMenu.settings.MyPageActivity;
 import com.project.sinabro.toast.ToastSuccess;
 import com.project.sinabro.toast.ToastWarning;
 import com.project.sinabro.utils.TokenManager;
@@ -116,13 +118,25 @@ public class AddLocationInfoActivity extends AppCompatActivity {
                                 intent.putExtra("markerId_value", markerId);
                                 new ToastSuccess(getResources().getString(R.string.toast_modify_list_success), AddLocationInfoActivity.this);
                                 startActivity(intent);
+                            } else {
+                                switch (response.code()) {
+                                    case 401:
+                                        new ToastWarning(getResources().getString(R.string.toast_login_time_exceed), AddLocationInfoActivity.this);
+                                        // "로그인" 액티비티로 이동
+                                        final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                        startActivity(intent);
+                                        finish(); // 현재 액티비티 종료
+                                        break;
+                                    default:
+                                        new ToastWarning(getResources().getString(R.string.toast_none_status_code), AddLocationInfoActivity.this);
+                                }
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Place> call, Throwable t) {
-                            Toast.makeText(AddLocationInfoActivity.this, "PATCH failed..", Toast.LENGTH_SHORT).show();
-                            Logger.getLogger(MainActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                            // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                            new ToastWarning(getResources().getString(R.string.toast_server_error), AddLocationInfoActivity.this);
                         }
                     });
                 } else {
@@ -138,13 +152,25 @@ public class AddLocationInfoActivity extends AppCompatActivity {
                                 intent.putExtra("markerId_value", placeInformation.getMarkerId());
                                 new ToastSuccess(getResources().getString(R.string.toast_add_place_success), AddLocationInfoActivity.this);
                                 startActivity(intent);
+                            } else {
+                                switch (response.code()) {
+                                    case 401:
+                                        new ToastWarning(getResources().getString(R.string.toast_login_time_exceed), AddLocationInfoActivity.this);
+                                        // "로그인" 액티비티로 이동
+                                        final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                        startActivity(intent);
+                                        finish(); // 현재 액티비티 종료
+                                        break;
+                                    default:
+                                        new ToastWarning(getResources().getString(R.string.toast_none_status_code), AddLocationInfoActivity.this);
+                                }
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Place> call, Throwable t) {
-                            Toast.makeText(AddLocationInfoActivity.this, "save failed..", Toast.LENGTH_SHORT).show();
-                            Logger.getLogger(MainActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                            // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                            new ToastWarning(getResources().getString(R.string.toast_server_error), AddLocationInfoActivity.this);
                         }
                     });
                 }
@@ -198,13 +224,25 @@ public class AddLocationInfoActivity extends AppCompatActivity {
                             final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);
                             intent.putExtra("markerId_value", markerId);
                             startActivity(intent);
+                        } else {
+                            switch (response.code()) {
+                                case 401:
+                                    new ToastWarning(getResources().getString(R.string.toast_login_time_exceed), AddLocationInfoActivity.this);
+                                    // "로그인" 액티비티로 이동
+                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                    startActivity(intent);
+                                    finish(); // 현재 액티비티 종료
+                                    break;
+                                default:
+                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), AddLocationInfoActivity.this);
+                            }
                         }
                     }
 
                     @Override
                     public void onFailure(Call<Integer> call, Throwable t) {
-                        Toast.makeText(AddLocationInfoActivity.this, "PATCH failed..", Toast.LENGTH_SHORT).show();
-                        Logger.getLogger(MainActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), AddLocationInfoActivity.this);
                     }
                 });
             }

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
@@ -25,6 +25,7 @@ import com.project.sinabro.R;
 import com.project.sinabro.models.PeopleNumber;
 import com.project.sinabro.retrofit.headcountsAPI;
 import com.project.sinabro.retrofit.RetrofitService;
+import com.project.sinabro.toast.ToastWarning;
 import com.project.sinabro.utils.TokenManager;
 
 import java.util.ArrayList;
@@ -149,8 +150,8 @@ public class PlaceListActivity extends AppCompatActivity {
 
             @Override
             public void onFailure(Call<List<PeopleNumber>> call, Throwable t) {
-                Toast.makeText(PlaceListActivity.this, "get failed..", Toast.LENGTH_SHORT).show();
-                Logger.getLogger(MainActivity.class.getName()).log(Level.SEVERE, "Error occured", t);
+                // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                new ToastWarning(getResources().getString(R.string.toast_server_error), PlaceListActivity.this);
             }
         });
     }

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/bookmark/PlaceInListActivity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/bookmark/PlaceInListActivity.java
@@ -73,15 +73,15 @@ public class PlaceInListActivity extends AppCompatActivity {
         adapter = new ListViewAdapter();
 
         //Adapter 안에 아이템의 정보 담기
-        adapter.addItem(new PlaceItem("충북대학교 중앙도서관", "3층", 5));
-        adapter.addItem(new PlaceItem("양성재 학생생활관", "식당", 1));
-        adapter.addItem(new PlaceItem("충북대학교가나다라마바사아자", "205호", 10));
-        adapter.addItem(new PlaceItem("가나다라마바사 아자차카타하가", "205호", 100));
-        adapter.addItem(new PlaceItem("가나다라마바사아자차카 타하가", "205호", -1));
-        adapter.addItem(new PlaceItem("가나다라마바  사아자차카타하", "205호", -1));
-        adapter.addItem(new PlaceItem("샘마루(SAMMaru)", "113호", -1));
-        adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "205호", -1));
-        adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "203호", -1));
+//        adapter.addItem(new PlaceItem("충북대학교 중앙도서관", "3층", 5));
+//        adapter.addItem(new PlaceItem("양성재 학생생활관", "식당", 1));
+//        adapter.addItem(new PlaceItem("충북대학교가나다라마바사아자", "205호", 10));
+//        adapter.addItem(new PlaceItem("가나다라마바사 아자차카타하가", "205호", 100));
+//        adapter.addItem(new PlaceItem("가나다라마바사아자차카 타하가", "205호", -1));
+//        adapter.addItem(new PlaceItem("가나다라마바  사아자차카타하", "205호", -1));
+//        adapter.addItem(new PlaceItem("샘마루(SAMMaru)", "113호", -1));
+//        adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "205호", -1));
+//        adapter.addItem(new PlaceItem("충북대학교 소프트웨어학부", "203호", -1));
 
 //        final Intent intent = getIntent();
 //        Boolean input_value = intent.getBooleanExtra("input_value", false);


### PR DESCRIPTION
## 👀 이슈

resolve #112 

## 📌 개요

애플리케이션 내 `MainActivity` 하단에 배치되는 `Bottom Sheet Layout`에서 이동되는 다양한
UI 요소 및 액티비티(스캔 버튼, 장소 등록/수정 버튼, 즐겨찾기 등록/취소 버튼, 장소 등록/수정/삭제 액티비티)에
대하여 비회원 사용자가 해당 기능을 사용할 시에 JWT access token의 유효성 검증 후 토큰의 만료 및 존재 여부를
기반으로 제한을 두어 로그인 액티비티로 애플리케이션의 화면을 전환함으로써 로그인을 할 수 있도록 하였습니다.

## 👩‍💻 작업 사항

- `MainActivity` 파일 내 `스캔 버튼, 장소 등록/수정 버튼, 즐겨찾기 등록/취소 버튼` 이벤트 처리 메소드 내 토큰 유효성 검증 API 기능 추가
- `AddLocationInfoActivity` 파일 내 `장소 정보 등록/수정 버튼, 장소 정보 제거` 이벤트 처리 메소드 내 토큰 유효성 검증 API 기능 추가

## ✅ 참고 사항

없습니다
