### PR TITLE
[fix]: 장소 삭제 API 스펙 변경으로 인한 클라이언트 측 코드 수정 (#116)

### DIFF
--- a/app/src/main/java/com/project/sinabro/retrofit/PlacesAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/PlacesAPI.java
@@ -4,6 +4,8 @@ import com.project.sinabro.models.Place;
 
 import java.util.List;
 
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -23,5 +25,5 @@ public interface PlacesAPI {
     Call<Place> updatePlace(@Path("id") String id, @Body Place place);
 
     @DELETE("/api/places/private/{id}")
-    Call<Integer> deletePlace(@Path("id") String id);
+    Call<ResponseBody> deletePlace(@Path("id") String id);
 }


### PR DESCRIPTION
## 👀 이슈

resolve #116 

## 📌 개요

서버 측 `장소 삭제` API 스펙 중 `response body`의 형태가 기존 `숫자(number)`에서
`객체(Object)`로 변경됨에 따라 클라이언트 측 코드를 그에 맞게 수정하였습니다.

## 👩‍💻 작업 사항

- `장소 정보 추가` 액티비티 내 `장소 삭제` API 호출 코드 라인 수정
- `PlacesAPI` 인터페이스 내 `장소 삭제` API에 대한 응답 데이터의 타입을 `ResponseBody`으로 수정

## ✅ 참고 사항

없습니다
