### PR TITLE
[fix]: 기존 people_numbers collection명 변경으로 인한 기존 해당 model 파일, API 인터페이스 및 관련 코드 일괄 수정 (#118)

### DIFF
--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
@@ -18,11 +18,10 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.project.sinabro.MainActivity;
 import com.project.sinabro.R;
-import com.project.sinabro.models.PeopleNumber;
+import com.project.sinabro.models.Headcount;
 import com.project.sinabro.retrofit.headcountsAPI;
 import com.project.sinabro.retrofit.RetrofitService;
 import com.project.sinabro.toast.ToastWarning;
@@ -30,8 +29,6 @@ import com.project.sinabro.utils.TokenManager;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -117,19 +114,19 @@ public class PlaceListActivity extends AppCompatActivity {
         listview = findViewById(R.id.placeList_listView);
         adapter = new ListViewAdapter();
 
-        Call<List<PeopleNumber>> call = peopleNumbersAPI.getPlaceInformationsById(markerId);
-        call.enqueue(new Callback<List<PeopleNumber>>() {
+        Call<List<Headcount>> call = peopleNumbersAPI.getPlaceInformationsById(markerId);
+        call.enqueue(new Callback<List<Headcount>>() {
             @Override
-            public void onResponse(Call<List<PeopleNumber>> call, Response<List<PeopleNumber>> response) {
+            public void onResponse(Call<List<Headcount>> call, Response<List<Headcount>> response) {
                 if (response.isSuccessful() && response.body() != null) {
-                    List<PeopleNumber> placeInformations = response.body();
+                    List<Headcount> placeInformations = response.body();
                     if (!placeInformations.isEmpty()) {
                         address = placeInformations.get(0).getPlaceId().getAddress();
                         latitude = Double.valueOf(placeInformations.get(0).getPlaceId().getMarkerId().getLatitude());
                         longitude = Double.valueOf(placeInformations.get(0).getPlaceId().getMarkerId().getLongitude());
                         address_tv.setText(address);
                         for (int k = 0; k < placeInformations.size(); k++) {
-                            int peopleNum = placeInformations.get(k).getPeopleCount();
+                            int peopleNum = placeInformations.get(k).getHeadcount();
                             String placeName = placeInformations.get(k).getPlaceId().getPlaceName();
                             String detailAddress = placeInformations.get(k).getPlaceId().getDetailAddress();
                             long updateElapsedTime = placeInformations.get(k).getUpdateElapsedTime();
@@ -149,7 +146,7 @@ public class PlaceListActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onFailure(Call<List<PeopleNumber>> call, Throwable t) {
+            public void onFailure(Call<List<Headcount>> call, Throwable t) {
                 // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
                 new ToastWarning(getResources().getString(R.string.toast_server_error), PlaceListActivity.this);
             }

--- a/app/src/main/java/com/project/sinabro/models/Headcount.java
+++ b/app/src/main/java/com/project/sinabro/models/Headcount.java
@@ -2,7 +2,7 @@ package com.project.sinabro.models;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PeopleNumber {
+public class Headcount {
 
     @SerializedName("_id")
     private String id;
@@ -10,8 +10,8 @@ public class PeopleNumber {
     @SerializedName("placeId")
     private PlaceId placeId;
 
-    @SerializedName("peopleCount")
-    private int peopleCount;
+    @SerializedName("headcount")
+    private int headcount;
 
     @SerializedName("createdTime")
     private String createdTime;
@@ -35,12 +35,12 @@ public class PeopleNumber {
         this.placeId = placeId;
     }
 
-    public int getPeopleCount() {
-        return peopleCount;
+    public int getHeadcount() {
+        return headcount;
     }
 
-    public void setPeopleCount(int peopleCount) {
-        this.peopleCount = peopleCount;
+    public void setHeadcount(int headcount) {
+        this.headcount = headcount;
     }
 
     public String getCreatedTime() {

--- a/app/src/main/java/com/project/sinabro/retrofit/headcountsAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/headcountsAPI.java
@@ -1,7 +1,7 @@
 package com.project.sinabro.retrofit;
 
 import com.project.sinabro.models.Place;
-import com.project.sinabro.models.PeopleNumber;
+import com.project.sinabro.models.Headcount;
 
 import java.util.List;
 
@@ -13,11 +13,11 @@ import retrofit2.http.Path;
 
 public interface headcountsAPI {
     @GET("/api/headcounts/public/placeInformations")
-    Call<List<PeopleNumber>> getPlaceInformations();
+    Call<List<Headcount>> getPlaceInformations();
 
     @GET("/api/headcounts/public/{id}/placeInformations")
-    Call<List<PeopleNumber>> getPlaceInformationsById(@Path("id") String id);
+    Call<List<Headcount>> getPlaceInformationsById(@Path("id") String id);
 
     @POST("/api/headcounts/private")
-    Call<Place> addPeopleNumber(@Body PeopleNumber peopleNumber);
+    Call<Place> addPeopleNumber(@Body Headcount peopleNumber);
 }


### PR DESCRIPTION
## 👀 이슈

resolve #118 

## 📌 개요

기존 `mongoDB` 내 인원수 정보를 저장하기 위한 `collection`으로 `people_numbers`라는 이름으로
collection을 사용하였는데, 좀 더 단순화된 표현을 사용하기 위해 `headcounts`로 변경됨에 따라 해당
이름을 사용하던 클라이언트 측 코드 및 파일명을 일괄적으로 수정하였습니다.

## 👩‍💻 작업 사항

- `PlaceListActivity` 액티비티 내 `특정 장소에 대한 인원수 세부 정보 조회` API 사용 코드 수정
- 기존 `people_numbers` collection에 대한 모델 파일명 수정
- `headcountsAPI` 인터페이스 내 APIs `Response Body` 타입 수정
- `MainActivity` 액티비티 내 `등록된 모든 장소에 대한 세부 정보 반환` API 사용 코드 수정

## ✅ 참고 사항

없습니다
