### PR TITLE
[feat]: Kakao Developers APIs 사용으로 인한 앱 REST API 키 환경 변수 입력 라인 추가 (#120)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+KAKAO_API_KEY=


### PR DESCRIPTION
## 👀 이슈

resolve #120 

## 📌 개요

클라이언트 애플리케이션 내에서 `Kakao Developers` APIs 사용으로 인해 애플리케이션
프로젝트 `gradle.properties` 파일 내 `REST API` 키 환경 변수 입력 라인을 추가하였습니다.

## 👩‍💻 작업 사항

- `gradle.properties` 파일 내 앱 `Kakao Developers - REST API 키` 환경 변수 입력 라인 추가

## ✅ 참고 사항

없습니다
