### PR TITLE
[fix]: 일부 액티비티 내에서 회원 전용 기능 사용 분리를 위한 액세스 토큰 유효성 체크 코드 추가 및 즐겨찾기 버튼 모양 변경 로직 추가 (#142)

### DIFF
--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -369,48 +369,24 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                 intent.putExtra("markerId_value", selectedMarkerId);
                                 intent.putExtra("address_value", finalAddress_value);
 
-                                call_userAPI_getUserSelfInfo.enqueue(new Callback<ResponseBody>() {
-                                    @Override
-                                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                                        if (response.isSuccessful()) {
-                                            if (addedPlaceInfoState.equals("0")) {
-                                                final Intent intent = new Intent(MainActivity.this, AddPlaceGuideActivity.class);
-                                                intent.putExtra("markerId_value", selectedMarkerId);
-                                                intent.putExtra("latitude_value", latitude);
-                                                intent.putExtra("longitude_value", longitude);
-                                                intent.putExtra("placeName_value", selectedPlaceName);
-                                                intent.putExtra("detailAddress_value", selectedDetailAddress);
-                                                intent.putExtra("placeId_value", selectedPlaceId);
-                                                intent.putExtra("markerId_value", selectedMarkerId);
-                                                intent.putExtra("address_value", finalAddress_value);
-                                                startActivity(intent);
-                                                return;
-                                            }
+                                if (addedPlaceInfoState.equals("0")) {
+                                    final Intent intent = new Intent(MainActivity.this, AddPlaceGuideActivity.class);
+                                    intent.putExtra("markerId_value", selectedMarkerId);
+                                    intent.putExtra("latitude_value", latitude);
+                                    intent.putExtra("longitude_value", longitude);
+                                    intent.putExtra("placeName_value", selectedPlaceName);
+                                    intent.putExtra("detailAddress_value", selectedDetailAddress);
+                                    intent.putExtra("placeId_value", selectedPlaceId);
+                                    intent.putExtra("markerId_value", selectedMarkerId);
+                                    intent.putExtra("address_value", finalAddress_value);
+                                    startActivity(intent);
+                                }
 
-                                            final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);
-                                            intent.putExtra("markerId_value", selectedMarkerId);
-                                            startActivity(intent);
-                                        } else {
-                                            switch (response.code()) {
-                                                case 401:
-                                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
-                                                    startActivity(intent);
-                                                    break;
-                                                default:
-                                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), MainActivity.this);
-                                            }
-                                        }
-                                    }
-
-                                    @Override
-                                    public void onFailure(Call<ResponseBody> call, Throwable t) {
-                                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
-                                        new ToastWarning(getResources().getString(R.string.toast_server_error), MainActivity.this);
-                                    }
-                                });
+                                final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);
+                                intent.putExtra("markerId_value", selectedMarkerId);
+                                startActivity(intent);
                             } else {
                                 new ToastWarning(getResources().getString(R.string.toast_cannot_access_area), MainActivity.this);
-                                return;
                             }
                         }
                     }
@@ -957,7 +933,6 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
         // 다이얼로그 창이 나타나면서 외부 액티비티가 어두워지는데, 그 정도를 조절함
         ask_add_or_cancel_bookmark_dialog.getWindow().setDimAmount(0.35f);
 
-        Button bookmarkFilled_btn = findViewById(R.id.bookmarkFilled_btn);
         TextView dialog_tv = ask_add_or_cancel_bookmark_dialog.findViewById(R.id.dialog_tv);
         if (bookmarkFilled_btn.getVisibility() == View.VISIBLE) {
             dialog_tv.setText(getResources().getString(R.string.dialog_cancel_bookmark));
@@ -982,15 +957,14 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
             @Override
             public void onClick(View view) {
                 ask_add_or_cancel_bookmark_dialog.dismiss(); // 다이얼로그 닫기
+                final Intent intent;
                 if (bookmarked) {
-                    final Intent intent = new Intent(getApplicationContext(), RemoveBookmarkFromListActivity.class);
-                    intent.putExtra("placeId", selectedPlaceId);
-                    startActivity(intent);
+                    intent = new Intent(getApplicationContext(), RemoveBookmarkFromListActivity.class);
                 } else {
-                    final Intent intent = new Intent(getApplicationContext(), AddBookmarkToListActivity.class);
-                    intent.putExtra("placeId", selectedPlaceId);
-                    startActivity(intent);
+                    intent = new Intent(getApplicationContext(), AddBookmarkToListActivity.class);
                 }
+                intent.putExtra("placeId", selectedPlaceId);
+                startActivity(intent);
             }
         });
     }

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/AddBookmarkToListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/AddBookmarkToListActivity.java
@@ -23,6 +23,7 @@ import com.project.sinabro.MainActivity;
 import com.project.sinabro.R;
 import com.project.sinabro.databinding.ActivityAddBookmarkToListBinding;
 import com.project.sinabro.models.Bookmark;
+import com.project.sinabro.models.Place;
 import com.project.sinabro.retrofit.RetrofitService;
 import com.project.sinabro.retrofit.interfaceAPIs.BookmarksAPI;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
@@ -59,7 +60,7 @@ public class AddBookmarkToListActivity extends AppCompatActivity {
 
     private Intent intent;
 
-    private String placeId;
+    private String placeId, departActivity;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -73,6 +74,7 @@ public class AddBookmarkToListActivity extends AppCompatActivity {
 
         intent = getIntent();
         placeId = intent.getStringExtra("placeId");
+        departActivity = intent.getStringExtra("departActivity");
 
         /** "즐겨찾기 추가/취소 확인" 다이얼로그 변수 초기화 및 설정 */
         ask_add_or_cancel_bookmark_dialog = new Dialog(AddBookmarkToListActivity.this);  // Dialog 초기화
@@ -225,8 +227,15 @@ public class AddBookmarkToListActivity extends AppCompatActivity {
                     @Override
                     public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
                         if (response.isSuccessful()) {
-                            MainActivity mainActivity = new MainActivity();
-                            mainActivity.updateBookmarkBtnState(true);
+                            if (departActivity.equals("PlaceListActivity")) {
+                                PlaceListActivity placeListActivity = new PlaceListActivity();
+                                placeListActivity.updateBookmarkBtnState(true);
+                                new ToastSuccess(getResources().getString(R.string.toast_add_bookmark_to_list_success), AddBookmarkToListActivity.this);
+                                finish(); // 현재 액티비티 종료
+                            } else {
+                                MainActivity mainActivity = new MainActivity();
+                                mainActivity.updateBookmarkBtnState(true);
+                            }
                             new ToastSuccess(getResources().getString(R.string.toast_add_bookmark_to_list_success), AddBookmarkToListActivity.this);
                             finish(); // 현재 액티비티 종료
                         } else {

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/RemoveBookmarkFromListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/RemoveBookmarkFromListActivity.java
@@ -21,6 +21,7 @@ import com.project.sinabro.MainActivity;
 import com.project.sinabro.R;
 import com.project.sinabro.databinding.ActivityRemoveBookmarkFromListBinding;
 import com.project.sinabro.models.Bookmark;
+import com.project.sinabro.models.Place;
 import com.project.sinabro.retrofit.RetrofitService;
 import com.project.sinabro.retrofit.interfaceAPIs.BookmarksAPI;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
@@ -55,7 +56,7 @@ public class RemoveBookmarkFromListActivity extends AppCompatActivity {
 
     private Intent intent;
 
-    private String placeId;
+    private String placeId, departActivity;
 
     List<Bookmark> bookmarkList = new ArrayList<>();
 
@@ -71,6 +72,7 @@ public class RemoveBookmarkFromListActivity extends AppCompatActivity {
 
         final Intent intent = getIntent();
         placeId = intent.getStringExtra("placeId");
+        departActivity = intent.getStringExtra("departActivity");
 
         /** "리스트 제거 확인 안내" 다이얼로그 변수 초기화 및 설정 */
         ask_add_or_cancel_bookmark_dialog = new Dialog(RemoveBookmarkFromListActivity.this);  // Dialog 초기화
@@ -222,8 +224,13 @@ public class RemoveBookmarkFromListActivity extends AppCompatActivity {
                     public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
                         if (response.isSuccessful()) {
                             if (bookmarkList.size() == bookmarkIds.size()) {
-                                MainActivity mainActivity = new MainActivity();
-                                mainActivity.updateBookmarkBtnState(false);
+                                if (departActivity.equals("PlaceListActivity")) {
+                                    PlaceListActivity placeListActivity = new PlaceListActivity();
+                                    placeListActivity.updateBookmarkBtnState(false);
+                                } else {
+                                    MainActivity mainActivity = new MainActivity();
+                                    mainActivity.updateBookmarkBtnState(false);
+                                }
                             }
                             new ToastSuccess(getResources().getString(R.string.toast_remove_bookmark_from_lists), RemoveBookmarkFromListActivity.this);
                             finish(); // 현재 액티비티 종료
@@ -275,14 +282,22 @@ public class RemoveBookmarkFromListActivity extends AppCompatActivity {
                     }
                 } else {
                     switch (response.code()) {
+
                         case 401:
                             new ToastWarning(getResources().getString(R.string.toast_login_time_exceed), RemoveBookmarkFromListActivity.this);
                             final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
                             startActivity(intent);
                             break;
                         case 404:
-                            MainActivity mainActivity = new MainActivity();
-                            mainActivity.updateBookmarkBtnState(false);
+                            if (departActivity.equals("departActivity")) {
+                                PlaceListActivity placeListActivity = new PlaceListActivity();
+                                placeListActivity.updateBookmarkBtnState(false);
+                            } else {
+                                MainActivity mainActivity = new MainActivity();
+                                mainActivity.updateBookmarkBtnState(false);
+                            }
+                            PlaceListActivity placeListActivity = new PlaceListActivity();
+                            placeListActivity.updateBookmarkBtnState(false);
                             binding.removeListListView.setVisibility(View.GONE);
                             binding.loadingTv.setVisibility(View.VISIBLE);
                             binding.loadingTv.setText("정보 없음");


### PR DESCRIPTION
## 👀 이슈

resolve #142 

## 📌 개요

현재 회원인 경우에만 사용 가능한 기능들이 존재하기 때문에 애플리케이션 내에서
비회원이 회원 기능 사용과 관련된 UI를 조작 할 때에 로그인 액티비티로 이동될 수
있도록 하고자 하였고, 장소 목록 액티비티 내에서 dialog로 표시되는 즐겨찾기 버튼에
대해 즐겨찾기 여부에 따라 버튼 모양이 변경될 수 있도록 관련 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- `MainActivity.java` 파일
> '장소 목록' 버튼 이벤트 내 로그인 여부 확인 코드 로직 제거 및 불필요 코드 제거, intent 설정 코드 수정
- `AddBookmarkToListActivity.java` 파일
- `RemoveBookmarkFromListActivity.java` 파일
> 장록 목록 액티비티 내 즐겨찾기 버튼 상태 변경 로직 추가
- `PlaceListActivity.java` 파일
> 장소 목록 액티비티 내 비회원의 회원 기능 사용 제한을 위한 로그인 여부 확인 코드 추가


## ✅ 참고 사항

- 기능 수정 후 `장소 목록` 액티비티 내 비회원의 회원 기능 사용에 대한 제한 처리 화면


