### PR TITLE
[bug]: MainActivity 액티비티 내 즐겨찾기 추가/삭제 관련 애플리케이션 종료 버그 및 장소 목록 액티비티 내 인원수 0명이 ?로 표기되는 에러 제거 (#144)

### DIFF
--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -964,6 +964,7 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                     intent = new Intent(getApplicationContext(), AddBookmarkToListActivity.class);
                 }
                 intent.putExtra("placeId", selectedPlaceId);
+                intent.putExtra("departActivity", "MainActivity");
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/place/PlaceListActivity.java
@@ -252,7 +252,7 @@ public class PlaceListActivity extends AppCompatActivity {
 
             placeName_tv.setText(placeItem.getPlaceName());
             placeInfo_tv.setText(placeItem.getDetailAddress());
-            if (placeItem.getPeopleCnt() > 0) {
+            if (placeItem.getPeopleCnt() >= 0) {
                 peopleCount_tv.setText("" + placeItem.getPeopleCnt());
             } else {
                 peopleCount_tv.setText("?");
@@ -294,7 +294,7 @@ public class PlaceListActivity extends AppCompatActivity {
         updateElapsedTime_tv_inDialog = placeInfo_dialog.findViewById(R.id.updateElapsedTime_tv);
 
         placeName_tv_inDialog.setText(placeItem.getPlaceName());
-        if (placeItem.getPeopleCnt() > 0) {
+        if (placeItem.getPeopleCnt() >= 0) {
             peopleCount_tv_inDialog.setText("" + placeItem.getPeopleCnt());
         } else {
             peopleCount_tv_inDialog.setText("?");


### PR DESCRIPTION
## 👀 이슈

resolve #144 

## 📌 개요

현재 MainActivity 액티비티 내 bottom sheet layout 내에서 등록된 장소에 대해서 즐겨찾기 추가/삭제
수행 시 애플리케이션이 비정상적으로 종료되고, 장소 목록 액티비티 내에서 0명으로 등록된 장소의 인원수가
? 값으로 표시되는 문제가 있어서 이 문제들을 해결하였습니다.

## 👩‍💻 작업 사항

- `MainActivity` 내 즐겨찾기 등록/삭제 관련 버그 제거
- `PlaceListActivity` 내 인원수 0명이 `?`로 표시되는 문제 해결

## ✅ 참고 사항

없습니다
