### PR TITLE
[feat]: 임시 비밀번호 생성 기능 추가 (#148)

### DIFF
--- a/app/src/main/java/com/project/sinabro/retrofit/interfaceAPIs/UserAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/interfaceAPIs/UserAPI.java
@@ -8,13 +8,17 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.PATCH;
+import retrofit2.http.POST;
 
 public interface UserAPI {
     @GET("/api/user/private/info")
     Call<ResponseBody> getUserSelfInfo();
 
+    @POST("api/user/generate-temp-password")
+    Call<UserInfo> generateTempPassword(@Body UserInfo userInfo);
+
     @PATCH("/api/user/private/point")
-    Call<ResponseBody> changePoint(@Body UserInfo user);
+    Call<ResponseBody> changePoint(@Body UserInfo userInfo);
 
     @PATCH("/api/user/private/info")
     Call<ResponseBody> changeUserSelfInfo(@Body UserInfo userInfo);

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/ResetPasswordActivity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/authentication/ResetPasswordActivity.java
@@ -12,7 +12,23 @@ import android.view.Window;
 
 import com.project.sinabro.R;
 import com.project.sinabro.databinding.ActivityResetPasswordBinding;
+import com.project.sinabro.models.UserInfo;
+import com.project.sinabro.retrofit.RetrofitService;
+import com.project.sinabro.retrofit.interfaceAPIs.UserAPI;
+import com.project.sinabro.sideBarMenu.settings.MyPageActivity;
 import com.project.sinabro.textWatcher.EmailWatcher;
+import com.project.sinabro.toast.ToastWarning;
+import com.project.sinabro.utils.TokenManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class ResetPasswordActivity extends AppCompatActivity {
 
@@ -20,11 +36,19 @@ public class ResetPasswordActivity extends AppCompatActivity {
 
     private Dialog resetPasswordSuccess_dialog;
 
+    private TokenManager tokenManager;
+    private RetrofitService retrofitService;
+    UserAPI userAPI;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityResetPasswordBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         /** "비밀번호 초기화 완료 안내" 다이얼로그 변수 초기화 및 설정 */
         resetPasswordSuccess_dialog = new Dialog(ResetPasswordActivity.this);  // Dialog 초기화
@@ -37,7 +61,6 @@ public class ResetPasswordActivity extends AppCompatActivity {
         binding.backIBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                onBackPressed(); // 뒤로가기 기능 수행
                 finish(); // 현재 액티비티 종료
             }
         });
@@ -58,13 +81,36 @@ public class ResetPasswordActivity extends AppCompatActivity {
                     return;
                 }
 
-                /* 이곳에 API 호출 코드가 추가되어야 합니다. */
+                binding.resetPasswordFailedTv.setVisibility(View.GONE);
 
-                // 입력된 이메일이 정상적으로 DB에서 조회되었을 때 다이얼로그 띄우기
-//                 showDialog_reset_password_success();
+                UserInfo userInfo = new UserInfo();
+                userInfo.setEmail(binding.emailEditText.getText().toString());
 
-                // 입력된 이메일이 DB에 존재하지 않을 경우 실패 메시지 보이게 하기
-                binding.resetPasswordFailedTv.setVisibility(View.VISIBLE);
+                Call<UserInfo> call_userAPI_generateTempPassword = userAPI.generateTempPassword(userInfo);
+                call_userAPI_generateTempPassword.enqueue(new Callback<UserInfo>() {
+                    @Override
+                    public void onResponse(Call<UserInfo> call, Response<UserInfo> response) {
+                        if (response.isSuccessful()) {
+                            // 입력된 이메일이 정상적으로 DB에서 조회되었을 때 다이얼로그 띄우기
+                            showDialog_reset_password_success();
+                        } else {
+                            switch (response.code()) {
+                                case 400:
+                                case 404:
+                                    binding.resetPasswordFailedTv.setVisibility(View.VISIBLE);
+                                    break;
+                                default:
+                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), ResetPasswordActivity.this);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<UserInfo> call, Throwable t) {
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), ResetPasswordActivity.this);
+                    }
+                });
             }
         });
     }

--- a/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
+++ b/app/src/main/java/com/project/sinabro/textWatcher/PasswordWatcher.java
@@ -64,7 +64,7 @@ public class PasswordWatcher implements TextWatcher {
     }
 
     public boolean validatePassword(String s) {
-        String passwordPattern = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&]).{7,20}.$";
+        String passwordPattern = "^.{8,20}$";
         return s.matches(passwordPattern);
     }
 }

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -157,7 +157,7 @@
             android:layout_alignParentRight="true"
             android:layout_marginTop="17.5dp"
             android:layout_marginEnd="45dp"
-            android:text="비밀번호찾기"
+            android:text="비밀번호를 잊으셨나요?"
             android:textColor="@color/blue" />
 
     </RelativeLayout>


### PR DESCRIPTION
## 👀 이슈

resolve #148 

## 📌 개요

사용자가 회원가입한 계정의 비밀번호를 기억하지 못 할 때
가입 메일로 임시 비밀번호를 전송하여 회원 정보를 찾을 수 있도록
하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `비밀번호 초기화` 액티비티 내에서 회원가입 중 사용한 이메일
입력 시 기존 비밀번호 초기화 후 임시 비밀번호를 해당 이메일 주소로
발송합니다.

## ✅ 참고 사항

- `임시 비밀번호 생성 기능` 추가 후 사용 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/8695a953-d076-4f96-a302-a7931fe08476