### PR TITLE
[bug]: 미등록 장소 클릭 후 '모두 보기' 클릭 시 '장소 등록 가이드' 액티비티 이동 실패 버그 제거 (#155)

### DIFF
--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -444,6 +444,7 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                                     intent.putExtra("placeId_value", selectedPlaceId);
                                     intent.putExtra("address_value", finalAddress_value);
                                     startActivity(intent);
+                                    return;
                                 }
 
                                 final Intent intent = new Intent(getApplicationContext(), PlaceListActivity.class);


### PR DESCRIPTION
## 👀 이슈

resolve #155 

## 📌 개요

장소 정보가 등록되지 않은 미등록 장소를 클릭 후 `bottom_sheet` Layout 내에
`모두 보기` 버튼 클릭 시 `장소 등록 가이드` 액티비티로 이동하는 것이 아닌 `장소 목록`
액티비티로 이동되는 버그가 발견되어 이를 제거하였습니다.

## 👩‍💻 작업 사항

- `MainActivity` 내에 `모두 보기` 버튼 클릭 시 `장소 등록 가이드` 액티비티 이동 섹션의 코드 부분 수정

## ✅ 참고 사항

- 버그 수정 전 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/ba5bd36a-97d6-4e3f-9f6c-7635643765e4

- 버그 수정 후 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/71f126e3-d695-4c6b-8494-bfe6c79ae5f6