### PR TITLE
[bug]: 장소 검색 후 장소 리스트 Item 클릭 시 앱 종료 버그 제거 (#157)

### DIFF
--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -73,6 +73,7 @@ import com.project.sinabro.retrofit.interfaceAPIs.UserAPI;
 import com.project.sinabro.search.SearchKeywordActivity;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
 import com.project.sinabro.sideBarMenu.settings.CheckPasswordActivity;
+import com.project.sinabro.sideBarMenu.settings.MyPageActivity;
 import com.project.sinabro.toast.ToastWarning;
 import com.project.sinabro.utils.TokenManager;
 
@@ -268,9 +269,6 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
                             searchedPlaceMarker.setMapPoint(MapPoint.mapPointWithGeoCoord(searchedLatitude, searchedLongitude));
                             searchedPlaceMarker.setMarkerType(MapPOIItem.MarkerType.YellowPin);
                             searchedPlaceMarker.setSelectedMarkerType(MapPOIItem.MarkerType.RedPin);
-
-                            mapView.selectPOIItem(markers.get(1), true);
-                            handlePOIItemSelected(markers.get(1));
 
                             String markerInfo = "-1" + "/" + searchedLatitude + "/" + searchedLongitude + "/" + "미등록 장소" + "/" + "" + "/" + "-1/null/null/0";
                             searchedPlaceMarker.setUserObject(markerInfo);
@@ -1393,5 +1391,10 @@ public class MainActivity extends AppCompatActivity implements MapView.CurrentLo
     @Override
     public void onDraggablePOIItemMoved(MapView mapView, MapPOIItem mapPOIItem, MapPoint
             mapPoint) {
+    }
+
+    @Override
+    public void onBackPressed() {
+        System.exit(0);
     }
 }

--- a/app/src/main/java/com/project/sinabro/MainActivity.java
+++ b/app/src/main/java/com/project/sinabro/MainActivity.java
@@ -73,7 +73,6 @@ import com.project.sinabro.retrofit.interfaceAPIs.UserAPI;
 import com.project.sinabro.search.SearchKeywordActivity;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
 import com.project.sinabro.sideBarMenu.settings.CheckPasswordActivity;
-import com.project.sinabro.sideBarMenu.settings.MyPageActivity;
 import com.project.sinabro.toast.ToastWarning;
 import com.project.sinabro.utils.TokenManager;
 


### PR DESCRIPTION
## 👀 이슈

resolve #157 

## 📌 개요

DB `places` collection 내에 장소 정보를 담고 있는 document가 2개 미만으로
존재하는 경우 애플리케이션 내에서 장소 검색 후 장소 리스트 Item 클릭 시 애플리케이션이
종료되는 문제가 있어서 이 문제를 제거하였습니다.

## 👩‍💻 작업 사항

- `MainActivity.java` 자바 클래스 내에 버그 유발 코드 일괄 제거
- `MainActivity.java` 자바 클래스 내에 뒤로가기 기능 사용 시 애플리케이션 종료 기능 추가

## ✅ 참고 사항

- 버그 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/49f2e3a0-e2a7-47fa-9e86-180661049c27

- 버그 제거 후 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/0d1ad934-5037-46ce-9480-1382caee42e2