### PR TITLE
[feat]: `회원 탈퇴 및 사유 기록` 기능 추가 (#159)

### DIFF
--- a/app/src/main/java/com/project/sinabro/models/UserWithdrawalReason.java
+++ b/app/src/main/java/com/project/sinabro/models/UserWithdrawalReason.java
@@ -1,0 +1,31 @@
+package com.project.sinabro.models;
+
+public class UserWithdrawalReason {
+    private String withdrawalReason;
+    private String feedback;
+    private String createdTime;
+
+    public String getWithdrawalReason() {
+        return withdrawalReason;
+    }
+
+    public void setWithdrawalReason(String withdrawalReason) {
+        this.withdrawalReason = withdrawalReason;
+    }
+
+    public String getFeedback() {
+        return feedback;
+    }
+
+    public void setFeedback(String feedback) {
+        this.feedback = feedback;
+    }
+
+    public String getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(String createdTime) {
+        this.createdTime = createdTime;
+    }
+}

--- a/app/src/main/java/com/project/sinabro/retrofit/interfaceAPIs/AuthAPI.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/interfaceAPIs/AuthAPI.java
@@ -1,12 +1,17 @@
 package com.project.sinabro.retrofit.interfaceAPIs;
 
+import com.project.sinabro.models.UserWithdrawalReason;
 import com.project.sinabro.models.requests.LoginRequest;
 import com.project.sinabro.models.UserInfo;
+
+import java.util.List;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.HTTP;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
 
@@ -19,4 +24,7 @@ public interface AuthAPI {
 
     @POST("/api/auth/public/sign-up")
     Call<UserInfo> signUp(@Body UserInfo userinfo);
+
+    @HTTP(method = "DELETE", path = "/api/auth/private/delete-account", hasBody = true)
+    Call<ResponseBody> deleteAccount(@Body UserWithdrawalReason userWithdrawalReason);
 }

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/settings/WithdrawalStep1Activity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/settings/WithdrawalStep1Activity.java
@@ -32,6 +32,7 @@ public class WithdrawalStep1Activity extends AppCompatActivity {
             public void onClick(View view) {
                 // 회원탈퇴 단계(2) 액티비티로 이동
                 final Intent intent = new Intent(getApplicationContext(), WithdrawalStep2Activity.class);
+                intent.putExtra("withdrawalReason", binding.dontUseAppTv.getText().toString());
                 startActivity(intent);
             }
         });
@@ -41,6 +42,7 @@ public class WithdrawalStep1Activity extends AppCompatActivity {
             public void onClick(View view) {
                 // 회원탈퇴 단계(2) 액티비티로 이동
                 final Intent intent = new Intent(getApplicationContext(), WithdrawalStep2Activity.class);
+                intent.putExtra("withdrawalReason", binding.securityConcernTv.getText().toString());
                 startActivity(intent);
             }
         });
@@ -50,6 +52,7 @@ public class WithdrawalStep1Activity extends AppCompatActivity {
             public void onClick(View view) {
                 // 회원탈퇴 단계(2) 액티비티로 이동
                 final Intent intent = new Intent(getApplicationContext(), WithdrawalStep2Activity.class);
+                intent.putExtra("withdrawalReason", binding.etcTv.getText().toString());
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/com/project/sinabro/sideBarMenu/settings/WithdrawalStep2Activity.java
+++ b/app/src/main/java/com/project/sinabro/sideBarMenu/settings/WithdrawalStep2Activity.java
@@ -11,10 +11,24 @@ import android.view.View;
 import android.view.Window;
 import android.widget.Button;
 
+import com.project.sinabro.MainActivity;
 import com.project.sinabro.R;
+import com.project.sinabro.bottomSheet.place.AddBookmarkToListActivity;
+import com.project.sinabro.bottomSheet.place.PlaceListActivity;
 import com.project.sinabro.databinding.ActivityWithdrawalStep2Binding;
+import com.project.sinabro.models.UserWithdrawalReason;
+import com.project.sinabro.retrofit.RetrofitService;
+import com.project.sinabro.retrofit.interfaceAPIs.AuthAPI;
+import com.project.sinabro.retrofit.interfaceAPIs.BookmarksAPI;
 import com.project.sinabro.sideBarMenu.authentication.SignInActivity;
 import com.project.sinabro.toast.ToastSuccess;
+import com.project.sinabro.toast.ToastWarning;
+import com.project.sinabro.utils.TokenManager;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class WithdrawalStep2Activity extends AppCompatActivity {
 
@@ -22,11 +36,26 @@ public class WithdrawalStep2Activity extends AppCompatActivity {
 
     private Dialog askAcceptWithdrawal_dialog;
 
+    private String withdrawalReason;
+
+    private Intent intent;
+
+    private TokenManager tokenManager;
+    private RetrofitService retrofitService;
+    private AuthAPI authAPI;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityWithdrawalStep2Binding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(getApplicationContext());
+        retrofitService = new RetrofitService(tokenManager);
+        authAPI = retrofitService.getRetrofit().create(AuthAPI.class);
+
+        intent = getIntent();
+        withdrawalReason = intent.getStringExtra("withdrawalReason");
 
         /** "회원 탈퇴 질문 안내" 다이얼로그 변수 초기화 및 설정 */
         askAcceptWithdrawal_dialog = new Dialog(WithdrawalStep2Activity.this);  // Dialog 초기화
@@ -73,11 +102,42 @@ public class WithdrawalStep2Activity extends AppCompatActivity {
         askAcceptWithdrawal_dialog.findViewById(R.id.yesBtn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                askAcceptWithdrawal_dialog.dismiss(); // 다이얼로그 닫기
-                new ToastSuccess(getResources().getString(R.string.toast_withdrawal_success), WithdrawalStep2Activity.this);
-                // 로그인 액티비티로 이동
-                final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
-                startActivity(intent);
+                UserWithdrawalReason userWithdrawalReason = new UserWithdrawalReason();
+                userWithdrawalReason.setWithdrawalReason(withdrawalReason);
+                String feedback = binding.feedbackEdt.getText().toString();
+                if (feedback.equals(""))
+                    feedback = "없음";
+                userWithdrawalReason.setFeedback(feedback);
+
+                Call<ResponseBody> call_authAPI_deleteAccount = authAPI.deleteAccount(userWithdrawalReason);
+                call_authAPI_deleteAccount.enqueue(new Callback<ResponseBody>() {
+                    @Override
+                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                        if (response.isSuccessful()) {
+                            tokenManager.logout();
+                            askAcceptWithdrawal_dialog.dismiss(); // 다이얼로그 닫기
+                            new ToastSuccess(getResources().getString(R.string.toast_withdrawal_success), WithdrawalStep2Activity.this);
+                            // 메인 액티비티로 이동
+                            final Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+                            startActivity(intent);
+                        } else {
+                            switch (response.code()) {
+                                case 401:
+                                    final Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+                                    startActivity(intent);
+                                    break;
+                                default:
+                                    new ToastWarning(getResources().getString(R.string.toast_none_status_code), WithdrawalStep2Activity.this);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                        // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                        new ToastWarning(getResources().getString(R.string.toast_server_error), WithdrawalStep2Activity.this);
+                    }
+                });
             }
         });
     }

--- a/app/src/main/res/layout/activity_withdrawal_step2.xml
+++ b/app/src/main/res/layout/activity_withdrawal_step2.xml
@@ -58,6 +58,7 @@
                         android:textStyle="bold" />
 
                     <EditText
+                        android:id="@+id/feedback_edt"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/get_personal_information_title_tv"


### PR DESCRIPTION
## 👀 이슈

resolve #159 

## 📌 개요

기존에 애플리케이션 내에 추가되어 있던 `회원탈퇴 관련` 액티비티에 대해
`회원탈퇴` API 사용 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `회원 탈퇴 및 사유 기록` 기능 추가

## ✅ 참고 사항

- `회원 탈퇴 및 사유 기록` 기능 사용 화면

https://github.com/Sinabro-littlebylittle/sinabroClient/assets/56868605/fb68f820-4080-4738-9745-d9b8bb22e5e8