### PR TITLE
[fix]: Retrofit URL Settings 관련 gradle.properties 파일 내에 환경 변수 추가 (#163)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField 'String', 'KAKAO_API_KEY', KAKAO_API_KEY
+        buildConfigField 'String', 'RETROFIT_MONGO_DB_SERVER_URL', RETROFIT_MONGO_DB_SERVER_URL
+        buildConfigField 'String', 'RETROFIT_FLASK_SERVER_URL', RETROFIT_FLASK_SERVER_URL
     }
 
     buildTypes {

--- a/app/src/main/java/com/project/sinabro/bottomSheet/headcount/ObjectDetectionActivity.kt
+++ b/app/src/main/java/com/project/sinabro/bottomSheet/headcount/ObjectDetectionActivity.kt
@@ -21,7 +21,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.project.sinabro.R
 import com.project.sinabro.databinding.ActivityObjectDetectionBinding
-import com.project.sinabro.retrofit.RetrofitServiceForHeadCount
+import com.project.sinabro.retrofit.RetrofitServiceForHeadcount
 import com.project.sinabro.retrofit.interfaceAPIs.ModelAPI
 import com.project.sinabro.toast.ToastSuccess
 import com.project.sinabro.toast.ToastWarning
@@ -155,7 +155,8 @@ class ObjectDetectionActivity : AppCompatActivity() {
                             val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES).absolutePath +
                                     File.separator + "CameraX-Video" + File.separator + mediaStoreOutputOptions.contentValues.getAsString(MediaStore.MediaColumns.DISPLAY_NAME)+".mp4"
                             val file = File(path)
-                            val retrofitService = RetrofitServiceForHeadCount()
+                            val retrofitService =
+                                RetrofitServiceForHeadcount()
                             val modelAPI = retrofitService.retrofit.create(ModelAPI::class.java)
 
                             val requestFile = RequestBody.create(MediaType.parse("video/mp4"), file)

--- a/app/src/main/java/com/project/sinabro/retrofit/RetrofitService.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/RetrofitService.java
@@ -1,6 +1,7 @@
 package com.project.sinabro.retrofit;
 
 import com.google.gson.Gson;
+import com.project.sinabro.BuildConfig;
 import com.project.sinabro.utils.AuthInterceptor;
 import com.project.sinabro.utils.TokenManager;
 
@@ -23,7 +24,7 @@ public class RetrofitService {
                 .build();
 
         retrofit = new Retrofit.Builder()
-                .baseUrl("http://10.0.2.2:5050")
+                .baseUrl(BuildConfig.RETROFIT_MONGO_DB_SERVER_URL)
                 .client(client)
                 .addConverterFactory(GsonConverterFactory.create(new Gson()))
                 .build();

--- a/app/src/main/java/com/project/sinabro/retrofit/RetrofitServiceForHeadcount.java
+++ b/app/src/main/java/com/project/sinabro/retrofit/RetrofitServiceForHeadcount.java
@@ -1,6 +1,7 @@
 package com.project.sinabro.retrofit;
 
 import com.google.gson.Gson;
+import com.project.sinabro.BuildConfig;
 
 import java.util.concurrent.TimeUnit;
 
@@ -9,13 +10,12 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 
-public class RetrofitServiceForHeadCount {
+public class RetrofitServiceForHeadcount {
     private Retrofit retrofit;
 
-    public RetrofitServiceForHeadCount() {
+    public RetrofitServiceForHeadcount() {
         initializeRetrofit();
     }
-
 
 
     private void initializeRetrofit() {
@@ -27,7 +27,7 @@ public class RetrofitServiceForHeadCount {
 
         retrofit = new Retrofit.Builder()
                 .client(client)
-                .baseUrl("enter_your_url")
+                .baseUrl(BuildConfig.RETROFIT_FLASK_SERVER_URL)
                 .addConverterFactory(GsonConverterFactory.create(new Gson()))
                 .build();
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,13 @@ android.useAndroidX=true
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-KAKAO_API_KEY=
+##################################
+## Kakao developers KEY Settings #
+##################################
+KAKAO_API_KEY="Kakao developers application's REST API KEY"
+
+##########################
+## Retrofit URL Settings #
+##########################
+RETROFIT_MONGO_DB_SERVER_URL="http://10.0.2.2:5050"
+RETROFIT_FLASK_SERVER_URL="https://sinabromodel.run.goorm.site"


### PR DESCRIPTION
## 👀 이슈

resolve #163 

## 📌 개요

현재 서버 통신을 위해 사용 중인 `RetrofitService.java`, `RetrofitServiceForHeadcount.java` 파일 내에
retrofit **baseUrl** 메소드의 인수로 사용하던 URL 값들을 환경 변수로써 관리할 수 있도록 하였습니다.

## 👩‍💻 작업 사항

- `RetrofitService.java`  파일 내 retrofit **baseUrl** 메소드의 인수를 **환경 변수**로 변경
- `RetrofitServiceForHeadcount.java`  파일 내 retrofit **baseUrl** 메소드의 인수를 **환경 변수**로 변경

## ✅ 참고 사항

없습니다
